### PR TITLE
Vectorize methods for lsst sims/150917

### DIFF
--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -297,6 +297,53 @@ def caldj( int iy, int im, int id ):
                bad = "day"
           raise ValueError( "Julian date not computed. Bad {}".format(bad) )
 
+
+def caldjVector(np.ndarray[long, ndim=1] iy not None,
+                np.ndarray[long, ndim=1] im not None,
+                np.ndarray[long, ndim=1] id not None):
+     """
+     djm = caldjVector( iy, im, id )
+
+     where iy, im, id and djm are vectors
+
+     @palCaldj@
+
+     Raises
+     ------
+     ValueError if input arrays have different lengths
+
+     Bad input dates result in numpy.NaN for djm.
+
+     Note: This algorithm does not work for dates before
+     -4799 January 1
+
+     Note: If you pass in a two-digit year, this algorithm will
+     interpret it as being between 1949 and 2049
+     """
+
+     cdef int length = len(iy)
+
+     if len(im)!=length:
+         raise ValueError("You did not pass as many months as years " \
+                           + "to caldjVector")
+
+     if len(id)!=length:
+         raise ValueError("You did not pass as many days as years " \
+                           + "to caldjVector")
+
+     cdef np.ndarray mjd_out = np.empty(length, dtype=np.float64)
+     cdef double mjd
+     cdef int flag
+
+     for ii in range(length):
+         cpal.palCaldj(iy[ii], im[ii], id[ii], &mjd, &flag)
+         if flag == 0:
+             mjd_out[ii] = mjd
+         else:
+             mjd_out[ii] = np.NaN
+
+     return mjd_out
+
 def cldj( int iy, int im, int id ):
      """
      djm = cldj( iy, im, id )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1452,9 +1452,22 @@ def dsep( double a1, double b1, double a2, double b2 ):
 
 def dsepVector(np.ndarray a1, np.ndarray b1, np.ndarray a2, np.ndarray b2):
      """
-     this is dsep but it accepts and returns vectors
+     s = dsep( a1, b1, a2, b2 )
+
+     where a1, b1, a2, b2, and s are numpy arrays
+
+     @palDsep@
+
+     Raises
+     ------
+     ValueError if input arrays have different lengths
      """
      cdef int length=len(a1)
+
+     if len(b1)!=length or len(a2)!=length or len(b2)!=length:
+         raise ValueError("The arrays you passed to dsepVector " \
+                          + "are not of the same length")
+
      cdef np.ndarray dd = np.zeros(length, dtype=np.float64)
      cdef double d
      cdef int i

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2946,6 +2946,40 @@ def supgal( double dsl, double dsb ):
      cpal.palSupgal( dsl, dsb, &dl, &db )
      return (dl, db)
 
+def supgalVector(np.ndarray[double, ndim=1] dsl not None,
+                 np.ndarray[double, ndim=1] dsb not None):
+    """
+    (dl, db) = supgalVector( dsl, dsb )
+
+    where dsl, dsb, dl, and db are all numpy arrays
+
+    @palSupgal@
+
+    Raises
+    ------
+    ValueError if input arrays are of different lengths
+    """
+
+    cdef int length=len(dsl)
+
+    if len(dsb)!=length:
+        raise ValueError("You did not pass the same number of " \
+                         + "longitudes as latitudes into supgalVector")
+
+    cdef np.ndarray dl_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray db_out = np.empty(length, dtype=np.float64)
+
+    cdef double dl
+    cdef double db
+
+    for ii in range(length):
+        cpal.palSupgal(dsl[ii], dsb[ii], &dl, &db)
+        dl_out[ii] = dl
+        db_out[ii] = db
+
+    return (dl_out, db_out)
+
+
 def ue2el(np.ndarray[double, ndim=1] u not None, int jformr ):
     """
     (jform, epoch, orbinc, anode, perih, aorq, e, aorl, dm) = ue2el( u, jformr )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1097,6 +1097,20 @@ def dranrm( double angle ):
      """
      return cpal.palDranrm( angle )
 
+def dranrmVector(np.ndarray[double, ndim=1] angle not None):
+    """
+    a = dranrm( angle )
+
+    where a and angle are numpy arrays
+
+    @palDranrm@
+    """
+    cdef int length=len(angle)
+    cdef np.ndarray angle_out = np.empty(length, dtype=np.float)
+    for ii in range(length):
+        angle_out[ii] = cpal.palDranrm(angle[ii])
+    return angle_out
+
 def ds2tp( double ra, double dec, double raz, double decz ):
      """
      (xi, eta) = ds2tp( ra, dec, raz, decz )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1364,7 +1364,7 @@ def dtf2r( int ihour, int imin, double sec ):
      else:
           bad = ""
           if j==1:
-               bad = "Degree argument outside range 0-369"
+               bad = "Hour argument outside range 0-23"
           elif j==2:
                bad = "Minute argument outside range 0-59"
           else:

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1945,6 +1945,46 @@ def hfk5z( double rh, double dh, double epoch ):
      cpal.palHfk5z( rh, dh, epoch, &r5, &d5, &dr5, &dd5 )
      return (r5, d5, dr5, dd5)
 
+def hfk5zVector(np.ndarray[double, ndim=1] rh not None,
+                np.ndarray[double, ndim=1] dh not None,
+                double epoch):
+    """
+    (r5, d5, dr5, dd5) = hfk5zVector( rh, dh, epoch)
+
+    where rh, dh, r5, d5, dr5 and dd5 are all numpy arrays
+
+    @palHfk5z@
+
+    Raises
+    ------
+    ValueError if input RA and Dec arrays do not have the same length
+    """
+
+    cdef int length = len(rh)
+
+    if len(dh)!=length:
+        raise ValueError("You did not pass the same number of RAs as " \
+                         + "Decs to hfk5zVector")
+
+    cdef np.ndarray ra_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dec_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dr_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dd_out = np.empty(length, dtype=np.float64)
+
+    cdef double r5
+    cdef double d5
+    cdef double dr5
+    cdef double dd5
+
+    for ii in range(length):
+        cpal.palHfk5z( rh[ii], dh[ii], epoch, &r5, &d5, &dr5, &dd5 )
+        ra_out[ii] = r5
+        dec_out[ii] = d5
+        dr_out[ii] = dr5
+        dd_out[ii] = dd5
+
+    return (ra_out, dec_out, dr_out, dd_out)
+
 # We need to return the sign in order to work out whether -0
 # is a negative integer (important when parsing "-0 22 33.0"
 # sexagesimal format. I'm assuming that no-one is going to really

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -3235,16 +3235,35 @@ def pm( double r0, double d0, double pr, double pd,
      cpal.palPm( r0, d0, pr, pd, px, rv, ep0, ep1, &r1, &d1 )
      return (r1, d1)
 
-def pmVector( np.ndarray r0, np.ndarray d0, np.ndarray pr,
-     np.ndarray pd, np.ndarray px, np.ndarray rv, double ep0,
-     double ep1):
+def pmVector( np.ndarray[double, ndim=1] r0 not None,
+              np.ndarray[double, ndim=1] d0 not None,
+              np.ndarray[double, ndim=1] pr not None,
+              np.ndarray[double, ndim=1] pd not None,
+              np.ndarray[double, ndim=1] px not None,
+              np.ndarray[double, ndim=1] rv not None,
+              double ep0, double ep1):
      """
-     This is pm (see above), except that it accepts an
-     ndarray of values for each argument
+     (r1, d1) = pmVector( r0, d0, pr, pd, px, rv, ep0, ep1 )
+
+     where r0, d0, pr, pd, px, rv, r1, and d1 are all
+     numpy arrays
+
+     @palPm@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
 
      cdef int i
      cdef int length=len(r0)
+
+     if len(d0)!=length or len(pr)!=length or len(pd)!=length \
+     or len(px)!=length or len(rv)!=length:
+
+         raise ValueError("The arrays you passed into pmVector " \
+                          + "are not all of the same length")
+
      cdef np.ndarray r1out=np.zeros(length,dtype=np.float64)
      cdef np.ndarray d1out=np.zeros(length,dtype=np.float64)
      cdef double r1

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1870,6 +1870,39 @@ def galsup( double dl, double db ):
      cpal.palGalsup( dl, db, &dsl, &dsb )
      return (dsl, dsb)
 
+def galsupVector(np.ndarray[double, ndim=1] dl not None,
+                 np.ndarray[double, ndim=1] db not None):
+    """
+    (dsl, dsb) = galsupVector( dl, db )
+
+    where dl, db, dsl, and dsb are all numpy arrays
+
+    @palGalsup@
+
+    Raises
+    ------
+    ValueError if input arrays have different lengths
+    """
+
+    cdef int length=len(dl)
+
+    if len(db)!=length:
+        raise ValueError("You did not pass the same number of " \
+                         + "Galactic longitudes as Galactic latitudes " \
+                         + "into galsupVector")
+
+    cdef np.ndarray dsl_out = np.empty(length, dtype=np.float)
+    cdef np.ndarray dsb_out = np.empty(length, dtype=np.float)
+    cdef double dsl
+    cdef double dsb
+
+    for ii in range(length):
+        cpal.palGalsup(dl[ii], db[ii], &dsl, &dsb)
+        dsl_out[ii] = dsl
+        dsb_out[ii] = dsb
+
+    return (dsl_out, dsb_out)
+
 def ge50( double dl, double db ):
      """
      (rd, dd) = ge50( dl, db )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1304,6 +1304,48 @@ def dtf2d( int ihour, int imin, double sec ):
                bad = "Arcsec argument outside range 0-59.9999..."
           raise ValueError( bad )
 
+def dtf2dVector( np.ndarray[long, ndim=1] ihour not None,
+                 np.ndarray[long, ndim=1] imin not None,
+                 np.ndarray[double, ndim=1] sec not None):
+    """
+    days = dtf2dVector(ihour, imin, sec)
+
+    where ihour, imin, sec, and days are all numpy arrays
+
+    @palDtf2d@
+
+    Raises
+    ------
+    Raises a ValueError if inputs have different sizes.
+
+    Bad values (hour outside of 0-23 range; minute outside of
+    0-59 range, or second outside of 0-59.9999 range)
+    will result in numpy.NaNs in the output.
+    """
+    cdef int length = len(ihour)
+
+    if len(imin)!=length:
+        raise ValueError("In dtf2dVector, imin does not have the same length " \
+                         + "as ihour")
+
+    if len(sec)!=length:
+        raise ValueError("In dtf2dVector, sec does not have the same length " \
+                         + "as ihour")
+
+    cdef np.ndarray days = np.empty(length, dtype=np.float64)
+    cdef int flag
+    cdef double value
+
+    for ii in range(length):
+        cpal.palDtf2d( ihour[ii], imin[ii], sec[ii], &value, &flag )
+        if flag==0:
+            days[ii] = value
+        else:
+            days[ii] = np.NaN
+
+    return days
+
+
 def dtf2r( int ihour, int imin, double sec ):
      """
      rad = dtf2r( ihour, imin, sec )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -633,6 +633,39 @@ def dd2tf( int ndp, double days ):
      sign = csign.decode('UTF-8')
      return ( sign, ihmsf[0], ihmsf[1], ihmsf[2], ihmsf[3] )
 
+def dd2tfVector( int ndp, np.ndarray[double, ndim=1] days not None):
+    """
+    (sign, ih, im, is ,frac) = ddtf( ndp, dayList)
+
+    where ndp is an integer denoting the resolution to which the
+    fraction of seconds should be taken and dayList is a numpy
+    array of values to be converted. sign, ih, im, is, and frac
+    will also be numpy arrays corresponding to the elements in
+    dayList.
+
+    @palDd2tf@
+    """
+
+    cdef int length = len(days)
+
+    cdef np.ndarray sign_out = np.empty(length, dtype = (unicode, 1))
+    cdef np.ndarray ih_out = np.empty(length, dtype = np.int)
+    cdef np.ndarray im_out = np.empty(length, dtype = np.int)
+    cdef np.ndarray is_out = np.empty(length, dtype = np.int)
+    cdef np.ndarray frac_out = np.empty(length, dtype = np.int)
+
+    cdef char * csign = " "
+    cdef int ihmsf[4]
+    for row in range(length):
+        cpal.palDd2tf( ndp, days[row], csign, ihmsf)
+        sign_out[row] = csign.decode('UTF-8')
+        ih_out[row] = ihmsf[0]
+        im_out[row] = ihmsf[1]
+        is_out[row] = ihmsf[2]
+        frac_out[row] = ihmsf[3]
+
+    return (sign_out, ih_out, im_out, is_out, frac_out)
+
 def de2h( double ha, double dec, double phi ):
      """
      (az, el) = de2h( ha, dec, phi )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2399,11 +2399,25 @@ def galeq( double dl, double db ):
      cpal.palGaleq( dl, db, &dr, &dd )
      return (dr, dd)
 
-def galeqVector(np.ndarray dl, np.ndarray db):
+def galeqVector(np.ndarray[double, ndim=1] dl not None,
+                np.ndarray [double, ndim=1] db not None):
      """
-     this is galeq, but it accepts and returns vectors
+     (dr, dd) = galeqVector( dl, db )
+
+     where dl, db, dr, and dd are numpy arrays
+
+     @palGaleq@
+
+     Raises
+     ------
+     ValueError if input arrays are of different lengths
      """
      cdef int length=len(dl)
+
+     if len(db)!=length:
+         raise ValueError("You did not pass the same number of " \
+                          + "longitudes as latitudes to galeqVector")
+
      cdef np.ndarray drout = np.zeros(length, dtype=np.float64)
      cdef np.ndarray ddout = np.zeros(length, dtype=np.float64)
      cdef double dr

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -865,6 +865,36 @@ def dmoon( double date ):
           pv[i] = cpv[i]
      return pv
 
+
+def dmoonVector(np.ndarray[double, ndim=1] date):
+     """
+     (x, y, z, xd, yd, zd) = dmoon(date)
+
+     where date and all of the outputs are numpy arrays
+
+     @palDmoon@
+     """
+
+     cdef int length = len(date)
+     cdef np.ndarray x_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray y_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray z_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray xd_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray yd_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray zd_out = np.empty(length, dtype=np.float64)
+     cdef double cpv [6]
+
+     for ii in range(length):
+         cpal.palDmoon(date[ii], cpv)
+         x_out[ii] = cpv[0]
+         y_out[ii] = cpv[1]
+         z_out[ii] = cpv[2]
+         xd_out[ii] = cpv[3]
+         yd_out[ii] = cpv[4]
+         zd_out[ii] = cpv[5]
+
+     return (x_out, y_out, z_out, xd_out, yd_out, zd_out)
+
 def dmxm(np.ndarray[double, ndim=2] a not None, np.ndarray[double, ndim=2] b not None):
     """
     c = dmxm( a, b )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2711,14 +2711,32 @@ def mapqk( double rm, double dm, double pr, double pd, double px, double rv, np.
      cpal.palMapqk( rm, dm, pr, pd, px, rv, camprms, &ra, &da )
      return (ra, da)
 
-def mapqkVector( np.ndarray rm, np.ndarray dm, np.ndarray pr, np.ndarray pd,
-np.ndarray px, np.ndarray rv, np.ndarray[double, ndim=1] amprms not None):
+def mapqkVector( np.ndarray[double, ndim=1] rm not None,
+                 np.ndarray[double, ndim=1] dm not None,
+                 np.ndarray[double, ndim=1] pr not None,
+                 np.ndarray[double, ndim=1] pd not None,
+                 np.ndarray[double, ndim=1] px not None,
+                 np.ndarray[double, ndim=1] rv not None,
+                 np.ndarray[double, ndim=1] amprms not None):
      """
-     This is just mapqk except that it accepts a vector of inputs and
-     returns a vector of outputs
+     (ra, da) = mapqkVector( rm, dm, pr, pd, px, rv, amprms )
+
+     where rm, dm, pr, pd, px, rv, ra, and da are all numpy arrays
+
+     @palMapqk@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
      cdef int i
      cdef int length=len(rm)
+
+     if len(dm)!=length or len(pr)!=length or len(pd)!=length \
+     or len(px)!=length or len(rv)!=length:
+         raise ValueError("The arrays you passed into mapqkVector " \
+                          + "are not of the same length")
+
      cdef np.ndarray raout=np.zeros(length,dtype=np.float64)
      cdef np.ndarray decout=np.zeros(length,dtype=np.float64)
      cdef double ra

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -122,7 +122,7 @@ def altazVector(np.ndarray[double, ndim=1] ha not None,
      cdef int length = len(ha)
 
      if len(dec)!=length:
-         raise ValueError("You did not pass as many Decs as " \
+          raise ValueError("You did not pass as many Decs as " \
                            + "Hour Angles to altazVector")
 
      cdef np.ndarray azout = np.zeros(length, dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1403,15 +1403,29 @@ def ds2tp( double ra, double dec, double raz, double decz ):
      else:
           raise ValueError( "Antistart too far from axis" )
 
-def ds2tpVector( np.ndarray ra, np.ndarray dec, double raz, double decz ):
+def ds2tpVector( np.ndarray[double, ndim=1] ra not None,
+                 np.ndarray[double, ndim=1] dec not None,
+                 double raz, double decz ):
      """
-     This is just ds2tp, except that it takes an array of ra and array
-     of dec and calculates xi and eta for each relative to the scalar
-     raz and decz
+     (xi, eta) = ds2tp( ra, dec, raz, decz )
+
+     @palDs2tp@
+
+     Raises
+     ------
+     ValueError in input arrays are not of the same length
+
+     If bad input values are given, NaNs will be placed in
+     the output arrays
      """
      cdef int i
      cdef int j
      cdef int length=len(ra)
+
+     if len(dec)!=length:
+         raise ValueError("You did not pass as many RAs as Decs " \
+                          + "to ds2tpVector")
+
      cdef double xi
      cdef double eta
      cdef np.ndarray xiout=np.zeros(length,dtype=np.float64)
@@ -1422,12 +1436,9 @@ def ds2tpVector( np.ndarray ra, np.ndarray dec, double raz, double decz ):
           if j==0:
                xiout[i] = xi
                etaout[i] = eta
-          elif j==1:
-               raise ValueError( "Star too far from axis" )
-          elif j==2:
-               raise ValueError( "Antistar on tangent plane" )
           else:
-               raise ValueError( "Antistart too far from axis" )
+              xiout[i] = np.NaN
+              etaout[i] = np.NaN
 
      return xiout, etaout
 

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1016,7 +1016,7 @@ def dr2af( int ndp, double angle ):
 
 def dr2afVector( int ndp, np.ndarray[double, ndim=1] angle not None):
     """
-    (sign, id, im, is, frac) = dr2af( ndp, angle)
+    (sign, id, im, is, frac) = dr2afVector( ndp, angle)
 
     where angle is a numpy array of angles in radians
     and all outputs are numpy arrays of the same size

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -965,29 +965,35 @@ def dpavVector( np.ndarray[double, ndim=2] v1_in not None,
     """
 
     cdef nPts = v1_in.shape[0]
+    cdef nDim2 = len((<object> v2_in).shape)
 
-    if v2_in.shape[0] != 1 and v2_in.shape[0] != nPts:
+    if nDim2!=1 and v2_in.shape[0]!=nPts:
         raise ValueError("In dpavVector, v2 must either be a numpy array of " \
-                         + "shape (1, 3) or a numpy array of shape (n, 3) "\
+                         + "shape (3,) or a numpy array of shape (n, 3) "\
                          + "where n is the number of rows in v1")
 
-    if v1_in.shape[1] != 3:
+    if v1_in.shape[1]!=3:
         raise ValueError("In dpavVector, v1 must be a numpy array in which " \
                          + "each row has 3 elements. " \
                          + "Your rows have %d elements." % v1_in.shape[1])
 
-    if v2_in.shape[1] != 3:
+    if nDim2!=1 and v2_in.shape[1]!=3:
         raise ValueError("In dpavVector, v2 must be a numpy array in which " \
                          + "each row has 3 elements. " \
                          + "Your rows have %d elements." % v2_in.shape[1])
+
+    if nDim2==1 and v2_in.shape[0]!=3:
+        raise ValueError("The v2 you passed into dpavVector represents a single " \
+                         "point with %d elements; it should have 3 elements" \
+                         % v2_in.shape[0])
 
     cdef double cv1[3]
     cdef double cv2[3]
     cdef np.ndarray pa_out = np.ndarray(nPts, dtype=np.float)
 
-    if v2_in.shape[0] == 1:
+    if nDim2 == 1:
         for j in range(3):
-            cv2[j] = v2_in[0][j]
+            cv2[j] = v2_in[j]
         for i in range(nPts):
             for j in range(3):
                 cv1[j] = v1_in[i][j]

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1610,6 +1610,20 @@ def epj2d( double epj ):
      """
      return cpal.palEpj2d(epj)
 
+def epj2dVector(np.ndarray[double, ndim=1] epj not None):
+    """
+    d = epj2dVector(epj)
+
+    where both d and epj are numpy arrays
+
+    @palEpj2d@
+    """
+    cdef int length = len(epj)
+    cdef np.ndarray mjd = np.empty(length, dtype=np.float64)
+    for ii in range(length):
+        mjd[ii] = cpal.palEpj2d(epj[ii])
+    return mjd
+
 # epv goes here
 def epv( double date ):
     """

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1756,6 +1756,40 @@ def fk45z( double r1950, double d1950, double bepoch ):
      cpal.palFk45z( r1950, d1950, bepoch, &r2000, &d2000 )
      return (r2000, d2000)
 
+def fk45zVector(np.ndarray[double, ndim=1] r1950 not None,
+                np.ndarray[double, ndim=1] d1950 not None,
+                double bepoch):
+    """
+    (r2000, d2000) = fk45zVector(r1950, d1950, bepoch)
+
+    where r1950, d1950, r2000, d2000 are numpy arrays
+
+    @palFk45z@
+
+    Raises
+    ------
+    ValueError if input arrays are not of the same length
+    """
+
+    cdef int length = len(r1950)
+
+    if len(d1950)!=length:
+        raise ValueError("You did not pass the same number of Decs as " \
+                         + "RAs to fk45zVector")
+
+    cdef np.ndarray r2000_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray d2000_out = np.empty(length, dtype=np.float64)
+
+    cdef double r2000
+    cdef double d2000
+
+    for ii in range(length):
+        cpal.palFk45z(r1950[ii], d1950[ii], bepoch, &r2000, &d2000)
+        r2000_out[ii] = r2000
+        d2000_out[ii] = d2000
+
+    return (r2000_out, d2000_out)
+
 def fk524( double r2000, double d2000, double dr2000,
            double dd2000, double p2000, double v2000 ):
      """

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1859,6 +1859,48 @@ def fk54z(double r2000, double d2000, double bepoch):
                     &dr1950, &dd1950 )
      return (r1950, d1950, dr1950, dd1950 )
 
+def fk54zVector(np.ndarray[double, ndim=1] r2000 not None,
+                np.ndarray[double, ndim=1] d2000 not None,
+                double bepoch):
+    """
+    (r1950, d1950, dr1950, dd1950) = fk45zVector( r2000, d2000, bepoch )
+
+    where r2000, d2000, and the outputs are numpy arrays
+
+    @palFk54z@
+
+    Raises
+    ------
+    Value error if input arrays have different lengths
+    """
+
+    cdef int length = len(r2000)
+
+    if len(d2000)!=length:
+        raise ValueError("You did not pass the same number of Decs as " \
+                         + "RAs to fk54zVector")
+
+    cdef np.ndarray r1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray d1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dr1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dd1950_out = np.empty(length, dtype=np.float64)
+
+    cdef double r1950
+    cdef double d1950
+    cdef double dr1950
+    cdef double dd1950
+
+    for ii in range(length):
+        cpal.palFk54z(r2000[ii], d2000[ii], bepoch, \
+                      &r1950, &d1950, &dr1950, &dd1950)
+
+        r1950_out[ii] = r1950
+        d1950_out[ii] = d1950
+        dr1950_out[ii] = dr1950
+        dd1950_out[ii] = dd1950
+
+    return (r1950_out, d1950_out, dr1950_out, dd1950_out)
+
 def fk5hz( double r5, double d5, double epoch):
      """
      (rh, dh) = fk5hz( r5, d5, epoch )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2563,9 +2563,22 @@ def gmsta( double date, double ut1 ):
 
 def gmstaVector(np.ndarray date, np.ndarray ut1):
      """
-     this is gmsta except that it accepts and returns vectors
+     t = gmsta( date, ut1 )
+
+     where date, ut1, and t are all numpy arrays
+
+     @palGmsta@
+
+     Raises
+     ------
+     ValueError if input arrays are of different lengths
      """
      cdef int length = len(date)
+
+     if len(ut1)!=length:
+         raise ValueError("The arrays you passed into gmstaVector " \
+                          + "are of different lengths")
+
      cdef np.ndarray gmout = np.zeros(length, dtype=np.float)
      cdef int i
      for i in range(length):

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1495,7 +1495,7 @@ def dvxv( np.ndarray[double, ndim=1] va not None, np.ndarray[double, ndim=1] vb 
 
 def ecleq( double dl, double db, double date ):
      """
-     (dr, dd) = eqecl( dl, db, date )
+     (dr, dd) = ecleq( dl, db, date )
 
      @palEcleq@
      """

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2766,13 +2766,25 @@ def mapqkz( double rm, double dm, np.ndarray[double, ndim=1] amprms not None):
      return (ra, da)
 
 
-def mapqkzVector( np.ndarray rm, np.ndarray dm, np.ndarray[double, ndim=1] amprms not None):
+def mapqkzVector( np.ndarray[double, ndim=1] rm not None,
+                  np.ndarray[double, ndim=1] dm not None,
+                  np.ndarray[double, ndim=1] amprms not None):
      """
-     This is just mapqkz except that it accepts a vector of inputs
-     and returns a vector of outputs
+     (ra, da) = mapqkzVector( rm, dm, amprms )
+
+     @palMapqkz@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
      cdef int i
      cdef int length=len(rm)
+
+     if len(dm)!=length:
+         raise ValueError("You did not pass as many RAs as Decs to " \
+                           + "mapqkzVector")
+
      cdef np.ndarray raout=np.zeros(length,dtype=np.float64)
      cdef np.ndarray decout=np.zeros(length,dtype=np.float64)
      cdef double ra

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -298,13 +298,27 @@ def aopqk(double rap, double dap, np.ndarray[double, ndim=1] aoprms not None):
 
     return (aob,zob,hob,dob,rob)
 
-def aopqkVector(np.ndarray rap, np.ndarray dap, np.ndarray[double, ndim=1] aoprms not None):
+def aopqkVector(np.ndarray[double, ndim=1] rap not None,
+                np.ndarray[double, ndim=1] dap not None,
+                np.ndarray[double, ndim=1] aoprms not None):
     """
-    This is just aopqk, except that it accepts a vector of inputs and
-    returns a vector of outputs.
+    (aob, zob, hob, dob, rob) = aopqk( rap, dap, aoprms )
+
+    where rap, dap and all outputs are numpy arrays
+
+    @palAopqk@
+
+    Raises
+    ------
+    ValueError if input arrays are not of the same length
     """
     cdef int i
     cdef int length=len(rap)
+
+    if len(dap)!=length:
+         raise ValueError("You did not pass the same number of Decs " \
+                          + "as RAs to aopqkVector")
+
     cdef np.ndarray aobout = np.zeros(length,dtype=np.float64)
     cdef np.ndarray zobout = np.zeros(length,dtype=np.float64)
     cdef np.ndarray hobout = np.zeros(length,dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -939,6 +939,70 @@ def dpav( np.ndarray[double, ndim=1] v1 not None, np.ndarray[double, ndim=1] v2 
      result = cpal.palDpav( cv1, cv2 )
      return result
 
+def dpavVector( np.ndarray[double, ndim=2] v1_in not None,
+                np.ndarray v2_in not None):
+    """
+    pa = dpavVector(v1, v2)
+
+    where v1 is a 2-D numpy array in which each row is a different
+    point on the unit sphere.  v2 is either a 1-D numpy array
+    corresponding to one point on the unit sphere, in which case
+    pa is a numpy array of position angles between the points in
+    v1 and the point v2, or v2 is a 2-D numpy array of the same
+    shape as v1, in which case pa is a numpy array of position angles
+    between the points in v1 and the corresponding points in v2, i.e.
+
+    pa[0] = dpav(v1[0], v2[0])
+    pa[1] = dpav(v1[1], v2[1])
+    ...
+    pa[n] = dpav(v1[n], v2[n])
+
+    @palDpav@
+
+    Raises
+    ------
+    ValueError if the inputs are of the wrong shape
+    """
+
+    cdef nPts = v1_in.shape[0]
+
+    if v2_in.shape[0] != 1 and v2_in.shape[0] != nPts:
+        raise ValueError("In dpavVector, v2 must either be a numpy array of " \
+                         + "shape (1, 3) or a numpy array of shape (n, 3) "\
+                         + "where n is the number of rows in v1")
+
+    if v1_in.shape[1] != 3:
+        raise ValueError("In dpavVector, v1 must be a numpy array in which " \
+                         + "each row has 3 elements. " \
+                         + "Your rows have %d elements." % v1_in.shape[1])
+
+    if v2_in.shape[1] != 3:
+        raise ValueError("In dpavVector, v2 must be a numpy array in which " \
+                         + "each row has 3 elements. " \
+                         + "Your rows have %d elements." % v2_in.shape[1])
+
+    cdef double cv1[3]
+    cdef double cv2[3]
+    cdef np.ndarray pa_out = np.ndarray(nPts, dtype=np.float)
+
+    if v2_in.shape[0] == 1:
+        for j in range(3):
+            cv2[j] = v2_in[0][j]
+        for i in range(nPts):
+            for j in range(3):
+                cv1[j] = v1_in[i][j]
+
+            pa_out[i] = cpal.palDpav(cv1, cv2)
+    else:
+        for i in range(nPts):
+            for j in range(3):
+                cv1[j] = v1_in[i][j]
+                cv2[j] = v2_in[i][j]
+
+            pa_out[i] = cpal.palDpav(cv1, cv2)
+
+    return pa_out
+
 def dr2af( int ndp, double angle ):
      """
      (sign, id, im, is, frac) = dr2af( ndp, angle )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -423,22 +423,26 @@ def dbearVector( np.ndarray[ double, ndim=1] a1 not None,
     b_out[n] = bearing(a1[n], b1[n], a2[n], b2[n])
 
     @palDbear@
+
+    Raises
+    ------
+    Value error if input arrays have inconsistent lengths
     """
     cdef int length1 = len(a1)
     cdef int length2 = len(a2)
     if len(b1) != length1:
-        raise RuntimeError("The first two arguments of dbearVector must " \
-                           + "be numpy arrays with the same number of elements")
+        raise ValueError("The first two arguments of dbearVector must " \
+                         + "be numpy arrays with the same number of elements")
 
     if len(b2) != length2:
-        raise RuntimeError("The second two arguments of dbearVector must " \
-                           + "be numpy arrays with the same number of elements")
+        raise ValueError("The second two arguments of dbearVector must " \
+                         + "be numpy arrays with the same number of elements")
 
     if length2!=1 and length2!=length1:
-        raise RuntimeError("The second two arguments of dbearVector must " \
-                           + "either have the same number of elements " \
-                           + "as the first two arguments, or they must have " \
-                           + "only one element")
+        raise ValueError("The second two arguments of dbearVector must " \
+                         + "either have the same number of elements " \
+                         + "as the first two arguments, or they must have " \
+                         + "only one element")
 
     cdef np.ndarray b_out = np.zeros(length1, dtype=np.float64)
 
@@ -496,12 +500,16 @@ def daf2rVector(np.ndarray[long, ndim=1] ideg_in not None,
     asec > 59.99999
 
     @palDaf2r@
+
+    Raises
+    ------
+    ValueError if input arrays have inconsistent lengths
     """
     cdef int length = len(ideg_in)
 
     if len(iamin_in)!=length or len(asec_in)!=length:
-        raise RuntimeError("You need to pass the same number of degrees as " \
-                           + "minutes and seconds to daf2rVector")
+        raise ValueError("You need to pass the same number of degrees as " \
+                         + "minutes and seconds to daf2rVector")
 
     cdef np.ndarray ang_out = np.zeros(length, dtype=np.float64)
     cdef double rad
@@ -539,14 +547,19 @@ def dcc2sVector( np.ndarray[double, ndim=2] v_in not None):
     containing the corresponding spherical coordinates
 
     @palDcc2s@
+
+    Raises
+    ------
+    ValueError if you do not pass in a 2-D numpy array with
+    three columns
     """
 
     if v_in.shape[1] != 3:
-        raise RuntimeError("The input to dcc2sVector should be " \
-                           + "a 2-D numpy array in which each row " \
-                           + "is a point in 3-D Cartesian coordinates." \
-                           + " The rows of your input" \
-                           + " have %d dimensions" % v_in.shape[1])
+        raise ValueError("The input to dcc2sVector should be " \
+                         + "a 2-D numpy array in which each row " \
+                         + "is a point in 3-D Cartesian coordinates." \
+                         + " The rows of your input" \
+                         + " have %d dimensions" % v_in.shape[1])
 
     cdef int length = v_in.shape[0]
     cdef double cv[3]
@@ -585,12 +598,18 @@ def dcs2cVector( np.ndarray[double, ndim=1] a_in not None,
     where a and b are numpy arrays of spherical coordinates.
     v is a 2-D numpy array in which each row contains the
     directional cosines of the corresponding Cartesian coordinates
+
+    @palDcs2c@
+
+    Raises
+    ------
+    ValueError if input arrays have inconsisten lengths
     """
 
     cdef int length = len(a_in)
     if len(b_in) != length:
-        raise RuntimeError("You did not pass as many latitudes as longitudes " \
-                           + "into dcs2sVector")
+        raise ValueError("You did not pass as many latitudes as longitudes " \
+                         + "into dcs2sVector")
 
     cdef double cv[3]
     cdef np.ndarray v_out = np.zeros((length, 3), dtype=np.float64)
@@ -1817,12 +1836,16 @@ def pcdVector( double disco, np.ndarray[ double, ndim=1] x_in not None,
     pincushion distortion applied.
 
     @palPcd@
+
+    Raises
+    ------
+    ValueError if input arrays have inconsistent lengths
     """
 
     cdef int length = len(x_in)
     if len(y_in) != length:
-        raise RuntimeError("You did not pass the same number of x as y " \
-                           + "coordinates to pcdVector")
+        raise ValueError("You did not pass the same number of x as y " \
+                         + "coordinates to pcdVector")
 
     cdef np.ndarray x_out = np.zeros(length, dtype=np.float64)
     cdef np.ndarray y_out = np.zeros(length, dtype=np.float64)
@@ -2476,12 +2499,18 @@ def unpcdVector( double disco, np.ndarray[ double, ndim=1 ] x_in not None,
     where x and y are numpy arrays of x, y tangent plane coordinates and
     tx, ty are numpy arrays of tangent plane coordinates with the
     pincushion distortion removed
+
+    @palUnpcd@
+
+    Raises
+    ------
+    ValueError if input arrays have inconsistent lengths
     """
 
     cdef int length=len(x_in)
     if len(y_in) != length:
-        raise RuntimeError("You did not pass the same number of x as y " \
-                           + "coordinates to unpcdVector")
+        raise ValueError("You did not pass the same number of x as y " \
+                         + "coordinates to unpcdVector")
 
     cdef np.ndarray x_out = np.zeros(length, dtype=np.float64)
     cdef np.ndarray y_out = np.zeros(length, dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1587,6 +1587,21 @@ def epj( double date ):
      """
      return cpal.palEpj(date)
 
+def epjVector( np.ndarray[double, ndim=1] date not None):
+    """
+    e = epjVector( date )
+
+    where e and date are both numpy arrays
+
+    @palEpj@
+    """
+    cdef int length = len(date)
+    cdef np.ndarray epj = np.empty(length, dtype=np.float64)
+    for ii in range(length):
+        epj[ii] = cpal.palEpj(date[ii])
+    return epj
+
+
 def epj2d( double epj ):
      """
      d = epj2d( epj )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -3518,11 +3518,14 @@ def refz( double zu, double refa, double refb ):
     cpal.palRefz(zu,refa,refb,&zr)
     return zr
 
-def refzVector(np.ndarray zu, double refa, double refb):
+def refzVector(np.ndarray[double, ndim=1] zu not None,
+               double refa, double refb):
      """
-     this is just refz, but accepts a vector of zenith distances
-     and returns a vector of corrected zenith distances (the refraction
-     coefficients must be the same for all of the sources)
+     zr = refzVector( zu, refa, refb )
+
+     where zu and zr are numpy arrays
+
+     @palRefz@
      """
      cdef int length = len(zu)
      cdef np.ndarray zrout = np.zeros(length, dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -806,13 +806,27 @@ def de2h( double ha, double dec, double phi ):
      cpal.palDe2h( ha, dec, phi, &az, &el )
      return (az, el)
 
-def de2hVector( np.ndarray ha, np.ndarray dec, double phi ):
+def de2hVector( np.ndarray[double, ndim=1] ha not None,
+                np.ndarray[double, ndim=1] dec not None,
+                double phi ):
      """
-     This isjust de2h, except that it accepts a vector of inputs
-     and returns a vector of outputs
+     (az, el) = de2h( ha, dec, phi )
+
+     where ha, dec, az, and el are numpy arrays
+
+     @palDe2h@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
      cdef int i
      cdef int length=len(ha)
+
+     if len(dec)!=length:
+         raise ValueError("You did not pass the same number of " \
+                          + "Decs as Hour Angles to de2hVector")
+
      cdef np.ndarray azout = np.zeros(length,dtype=np.float64)
      cdef np.ndarray elout = np.zeros(length,dtype=np.float64)
      cdef double az

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1774,6 +1774,77 @@ def fk524( double r2000, double d2000, double dr2000,
                     &p1950, &v1950 )
      return (r1950, d1950, dr1950, dd1950, p1950, v1950 )
 
+def fk524Vector(np.ndarray[double, ndim=1] r2000 not None,
+                np.ndarray[double, ndim=1] d2000 not None,
+                np.ndarray[double, ndim=1] dr2000 not None,
+                np.ndarray[double, ndim=1] dd2000 not None,
+                np.ndarray[double, ndim=1] p2000 not None,
+                np.ndarray[double, ndim=1] v2000 not None):
+    """
+    (r1950, d1950, dr1950, dd1950, p1950, v1950) = fk524( r2000, d2000, dr2000, dd2000, p2000, v2000 )
+
+    where r2000, d2000, dr2000, dd2000, p2000, v2000,
+    r1950, d1950, dr1950, dd1950, p1950, and v1950 are
+    all numpy arrays
+
+    @palFk524@
+
+    Raises
+    ------
+    ValueError if input arrays do not all of the same length
+    """
+    cdef int length = len(r2000)
+
+    if len(d2000)!= length:
+        raise ValueError("You did not pass as many Decs as RAs into " \
+                         + "fk524Vector")
+
+    if len(dr2000)!= length:
+        raise ValueError("You did not pass as many RA proper motions as RAs into " \
+                         + "fk524Vector")
+
+    if len(dd2000)!= length:
+        raise ValueError("You did not pass as many Dec proper motions as RAs into " \
+                         + "fk524Vector")
+
+    if len(p2000)!= length:
+        raise ValueError("You did not pass as many parallaxes as RAs into " \
+                         + "fk524Vector")
+
+    if len(v2000)!= length:
+        raise ValueError("You did not pass as many radial velocities as RAs into " \
+                         + "fk524Vector")
+
+
+    cdef np.ndarray r1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray d1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dr1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dd1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray p1950_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray v1950_out = np.empty(length, dtype=np.float64)
+
+    cdef double r1950
+    cdef double d1950
+    cdef double dr1950
+    cdef double dd1950
+    cdef double p1950
+    cdef double v1950
+
+    for ii in range(length):
+        cpal.palFk524(r2000[ii], d2000[ii], dr2000[ii], dd2000[ii],
+                      p2000[ii], v2000[ii], &r1950, &d1950,
+                      &dr1950, &dd1950, &p1950, &v1950)
+
+        r1950_out[ii] = r1950
+        d1950_out[ii] = d1950
+        dr1950_out[ii] = dr1950
+        dd1950_out[ii] = dd1950
+        p1950_out[ii] = p1950
+        v1950_out[ii] = v1950
+
+    return (r1950_out, d1950_out, dr1950_out, dd1950_out,
+            p1950_out, v1950_out)
+
 def fk54z(double r2000, double d2000, double bepoch):
      """
      (r1950, d1950, dr1950, dd1950) = fk54z( r2000, d2000, bepoch )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2175,6 +2175,48 @@ def oapqk( type, double ob1, double ob2, np.ndarray[double, ndim=1] aoprms not N
      cpal.palOapqk( ctype, ob1, ob2, caoprms, &rap, &dap )
      return ( rap, dap )
 
+def oapqkVector(type,
+                np.ndarray[double, ndim=1] ob1 not None,
+                np.ndarray[double, ndim=1] ob2 not None,
+                np.ndarray[double, ndim=1] aoprms not None):
+    """
+    (rap, dap) = oapqkVector( type, ob1, ob2, aoprms )
+
+    where ob1, ob2, rap, dap are all numpy arrays
+
+    @palOapqk@
+
+    Raises
+    ------
+    ValueError if input coordinate arrays are of different length
+    """
+
+    cdef int length = len(ob1)
+    if len(ob2)!=length:
+        raise ValueError("The observed coordinate arrays you passed into " \
+                         + "oapqkVector are of different lengths")
+
+    cdef np.ndarray ra_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dec_out = np.empty(length, dtype=np.float64)
+
+    byte_string = type.encode('ascii')
+
+    cdef char * ctype = byte_string
+    cdef double caoprms[14]
+
+    for i in range(14):
+        caoprms[i] = aoprms[i]
+
+    cdef double rap
+    cdef double dap
+
+    for ii in range(length):
+        cpal.palOapqk( ctype, ob1[ii], ob2[ii], caoprms, &rap, &dap)
+        ra_out[ii] = rap
+        dec_out[ii] = dap
+
+    return (ra_out, dec_out)
+
 # Numeric lookup is only useful when scanning through the
 # list of telescopes. The python interface does not need this.
 # Instead obs() returns a dict (which may be a bit less efficient

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2953,13 +2953,26 @@ def pa( double ha, double dec, double phi):
      """
      return cpal.palPa( ha, dec, phi )
 
-def paVector(np.ndarray ha, np.ndarray dec, double phi):
+def paVector(np.ndarray[double, ndim=1] ha not None,
+             np.ndarray[double, ndim=1] dec not None,
+             double phi):
      """
-     This is pa, except that it accepts vectors of hour angle
-     and declination.  Latitude is still a double.
-     Vectors of parallactic angle are returned.
+     a = pa( ha, dec, phi )
+
+     where ha, dec, and a are all numpy arrays
+
+     @palPa@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
      cdef int length = len(ha)
+
+     if len(dec)!=length:
+         raise ValueError("You did not pass as many Decs as " \
+                          + "Hour Angles to paVector")
+
      cdef np.ndarray paOut = np.zeros(length, dtype=np.float64)
      cdef int i
      for i in range(length):

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1504,6 +1504,40 @@ def ecleq( double dl, double db, double date ):
      cpal.palEcleq( dl, db, date, &dr, &dd )
      return (dr, dd)
 
+def ecleqVector(np.ndarray[double, ndim=1] dl not None,
+                np.ndarray[double, ndim=1] db not None,
+                double date):
+    """
+    (dr, dd) = ecleqVector(dl, db, date)
+
+    where dl, db, dr, and dd are all numpy arrays
+
+    @palEcleq@
+
+    Raises
+    ------
+    ValueError if input arrays are of different lengths
+    """
+
+    cdef int length = len(dl)
+
+    if len(db)!=length:
+        raise ValueError("You did not pass the same number of " \
+                         + "longitudes as latitudes to ecleqVector")
+
+    cdef np.ndarray rr_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dd_out = np.empty(length, dtype=np.float64)
+
+    cdef double rr
+    cdef double dd
+
+    for ii in range(length):
+        cpal.palEcleq(dl[ii], db[ii], date, &rr, &dd)
+        rr_out[ii] = rr
+        dd_out[ii] = dd
+
+    return (rr_out, dd_out)
+
 def ecmat( double date ):
      """
      rmat = ecmat( date )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2086,12 +2086,26 @@ def eqgal( double dr, double dd ):
      cpal.palEqgal( dr, dd, &dl, &db )
      return (dl, db)
 
-def eqgalVector(np.ndarray dr, np.ndarray dd):
+def eqgalVector(np.ndarray[double, ndim=1] dr not None,
+                np.ndarray[double, ndim=1] dd not None):
      """
-     This is the same as eqgal, but it accepts and returns vectors
+     (dl, db) = eqgalVector( dr, dd )
+
+     where dr, dd, dl, db are all numpy arrays
+
+     @palEqgal@
+
+     Raises
+     ------
+     ValueError if input arrays are not of the same length
      """
 
      cdef int length=len(dr)
+
+     if len(dd) != length:
+         raise ValueError("You did not pass the same number of RAs " \
+                          + "as Decs to eqgalVector")
+
      cdef np.ndarray dlout = np.zeros(length, dtype=np.float64)
      cdef np.ndarray dbout = np.zeros(length, dtype=np.float64)
      cdef double dl

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2060,7 +2060,11 @@ def eqeqx( double date ):
 
 def eqeqxVector(np.ndarray date):
      """
-     this is eqeqx except that it accepts and returns vectors
+     eq = eqeqxVector( date )
+
+     where date and eq are numpy arrays
+
+     @palEqeqx@
      """
      cdef int length=len(date)
      cdef np.ndarray eqout = np.zeros(length, dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1053,6 +1053,34 @@ def dr2tf( int ndp, double angle ):
      sign = csign.decode('UTF-8')
      return ( sign, ihmsf[0], ihmsf[1], ihmsf[2], ihmsf[3] )
 
+def dr2tfVector( int ndp, np.ndarray[double, ndim=1] angle not None):
+    """
+    (sign, ih, im, is, frac) = dr2tfVector( ndp, angle)
+
+    where angle is a numpy array of angles in radians
+    and all outputs are numpy arrays of the same size
+
+    @palDr2tf@
+    """
+    cdef int length = len(angle)
+    cdef np.ndarray sign_out = np.ndarray(length, dtype=(unicode, 1))
+    cdef np.ndarray ih_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray im_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray isec_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray frac_out = np.ndarray(length, dtype=int)
+    cdef char * csign = " "
+    cdef int idmsf[4]
+
+    for ii in range(length):
+        cpal.palDr2tf(ndp, angle[ii], csign, idmsf)
+        sign_out[ii] = csign.decode('UTF-8')
+        ih_out[ii] = idmsf[0]
+        im_out[ii] = idmsf[1]
+        isec_out[ii] = idmsf[2]
+        frac_out[ii] = idmsf[3]
+
+    return (sign_out, ih_out, im_out, isec_out, frac_out)
+
 def drange( double angle ):
      """
      a = drange( angle )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -725,6 +725,40 @@ def dh2e( double az, double el, double phi ):
      cpal.palDh2e( az, el, phi, &ha, &dec )
      return (ha, dec)
 
+def dh2eVector(np.ndarray[double, ndim=1] az not None,
+               np.ndarray[double, ndim=1] el not None,
+               double phi):
+     """
+     (ha, dec) = dh2e( az, el, phi)
+
+     where az, el, ha, and dec are all numpy arrays
+
+     @palDh2e@
+
+     Raises
+     ------
+     ValueError if the input arrays are of different lengths
+     """
+
+     cdef int length = len(az)
+
+     if len(el)!=length:
+         raise ValueError("You did not pass as many elevations as " \
+                          + "azimuths to dh2eVector")
+
+     cdef np.ndarray ha_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray dec_out = np.empty(length, dtype=np.float64)
+
+     cdef double ha
+     cdef double dec
+
+     for ii in range(length):
+         cpal.palDh2e(az[ii], el[ii], phi, &ha, &dec)
+         ha_out[ii] = ha
+         dec_out[ii] = dec
+
+     return (ha_out, dec_out)
+
 def dimxv( np.ndarray[double, ndim=2] dm not None, np.ndarray[double, ndim=1] va not None):
      """
      vb = dimxv( dm, va )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1198,6 +1198,73 @@ def dsepv( np.ndarray[double, ndim=1] v1 not None, np.ndarray[double, ndim=1] v2
      result = cpal.palDsepv( cv1, cv2 )
      return result
 
+def dsepvVector(np.ndarray[double, ndim=2] v1 not None, np.ndarray v2 not None):
+    """
+    s = dsepvVector(v1, v2)
+
+    where v1 is a 2-D numpy array in which each row is a different 3-vector.
+    v2 is either a 1-D numpy array representing a 3-vector, in which case
+    s is a numpy array of the angular separation between each row of v1 and
+    v2, or v2 is a 2-D numpy array with the same shape as v1, in which case
+    s is a numpy array ofthe separation between the points in v1 and the
+    corresponding points in v2, i.e.
+
+    s[0] = dsepv(v1[0], v2[0])
+    s[1] = dsepv(v1[1], v2[1])
+    ...
+    s[n] = dsepv(v1[n], v2[n])
+
+    @palDsepv@
+
+    Raises
+    ------
+    ValueError if the inputs are not formatted correctly
+    """
+
+    cdef int nPts = v1.shape[0]
+    cdef int nDim2 = len((<object> v2).shape)
+
+    if nDim2!=1 and v2.shape[0]!=nPts:
+        raise ValueError("In dsepvVector v2 must either have one row or " \
+                         + "n rows, where n is the number of rows in v1")
+
+    if v1.shape[1]!=3:
+        raise ValueError("In dsepvVector v1 must be a numpy array " \
+                         + "in which each row corresponds to a direction " \
+                         + "in 3-D space.  Your v1 has %d columns." % v1.shape[1])
+
+    if nDim2!=1 and v2.shape[1]!=3:
+        raise ValueError("In dsepvVector v2 must be a numpy array " \
+                         + "in which each row corresponds to a direction " \
+                         + "in 3-D space.  Your v2 has %d columns." % v2.shape[1])
+
+    if nDim2==1 and v2.shape[0]!=3:
+        raise ValueError("The v2 you passed to dsepvVector is a single point " \
+                          + "with %d elements; it should have 3 elements" % v2.shape[0])
+
+
+    cdef double cv1[3]
+    cdef double cv2[3]
+
+    cdef np.ndarray sep = np.empty(nPts, dtype=np.float64)
+
+    if nDim2==1:
+        for i in range(3):
+            cv2[i] = v2[i]
+        for i in range(nPts):
+            for j in range(3):
+                cv1[j] = v1[i][j]
+            sep[i] = cpal.palDsepv(cv1, cv2)
+    else:
+        for i in range(nPts):
+            for j in range(3):
+                cv1[j] = v1[i][j]
+                cv2[j] = v2[i][j]
+            sep[i] = cpal.palDsepv(cv1, cv2)
+
+    return sep
+
+
 def dt( double epoch ):
      """
      d = dt( epoch )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2224,7 +2224,7 @@ def fk524Vector(np.ndarray[double, ndim=1] r2000 not None,
                 np.ndarray[double, ndim=1] p2000 not None,
                 np.ndarray[double, ndim=1] v2000 not None):
     """
-    (r1950, d1950, dr1950, dd1950, p1950, v1950) = fk524( r2000, d2000, dr2000, dd2000, p2000, v2000 )
+    (r1950, d1950, dr1950, dd1950, p1950, v1950) = fk524Vector( r2000, d2000, dr2000, dd2000, p2000, v2000 )
 
     where r2000, d2000, dr2000, dd2000, p2000, v2000,
     r1950, d1950, dr1950, dd1950, p1950, and v1950 are

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1881,6 +1881,39 @@ def ge50( double dl, double db ):
      cpal.palGe50( dl, db, &dr, &dd )
      return (dr, dd)
 
+def ge50Vector( np.ndarray[double, ndim=1] dl not None,
+                np.ndarray[double, ndim=1] db not None):
+    """
+    (rd, dd) = ge50( dl, db )
+
+    where dl, db, rd, and dd are all numpy arrays
+
+    @palGe50@
+
+    Raises
+    ------
+    ValueError if input arrays have different lengths
+    """
+
+    cdef int length = len(dl)
+
+    if len(db)!=length:
+        raise ValueError("You did not pass the same number of " \
+                         + "Galactic longitudes as Galactic latitudes " \
+                         + "into ge50Vector")
+
+    cdef np.ndarray dr_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dd_out = np.empty(length, dtype=np.float64)
+    cdef double dr
+    cdef double dd
+
+    for ii in range(length):
+        cpal.palGe50(dl[ii], db[ii], &dr, &dd)
+        dr_out[ii] = dr
+        dd_out[ii] = dd
+
+    return (dr_out, dd_out)
+
 def geoc( double p, double h ):
      """
      (r, z) = geoc( p, h )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1099,7 +1099,7 @@ def dranrm( double angle ):
 
 def dranrmVector(np.ndarray[double, ndim=1] angle not None):
     """
-    a = dranrm( angle )
+    a = dranrmVector( angle )
 
     where a and angle are numpy arrays
 

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1799,6 +1799,39 @@ def fk5hz( double r5, double d5, double epoch):
      cpal.palFk5hz( r5, d5, epoch, &rh, &dh )
      return (rh, dh)
 
+def fk5hzVector(np.ndarray[double, ndim=1] r5,
+                np.ndarray[double, ndim=1] d5,
+                double epoch):
+    """
+    (rh, dh) = fk5hzVector(r5, d5, epoch)
+
+    where rh, dh, r5, and d5 are numpy arrays
+
+    @palFk5hz@
+
+    Raises
+    ------
+    ValueError if r5 and d5 have different lengths
+    """
+
+    cdef int length = len(r5)
+
+    if len(d5)!=length:
+        raise ValueError("You did not pass the same number of " \
+                         "RAs as Decs to fk5hzVector")
+
+    cdef np.ndarray ra_out = np.ndarray(length, dtype=np.float64)
+    cdef np.ndarray dec_out = np.ndarray(length, dtype=np.float64)
+    cdef double rh
+    cdef double dh
+
+    for ii in range(length):
+        cpal.palFk5hz( r5[ii], d5[ii], epoch, &rh, &dh )
+        ra_out[ii] = rh
+        dec_out[ii] = dh
+
+    return (ra_out, dec_out)
+
 def galeq( double dl, double db ):
      """
      (dr, dd) = galeq( dl, db )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -763,6 +763,48 @@ def djcal( int ndp, double djm ):
      else:
           raise ValueError( "Unacceptable date" )
 
+
+def djcalVector(int ndp, np.ndarray[double, ndim=1] djm not None):
+     """
+     (iy, im, id, frac) = djcalVector( ndp, djm)
+
+     where djm and outputs are numpy arrays
+
+     @palDjcal@
+
+     Raises
+     ------
+     Does not raise any exceptions; unacceptable dates (mjd<-2468570
+     or mjd>1e9) result in -1 in iy, im, id and frac.
+
+     Note: -1 is a valid result of iy (not for im, id, or frac), so
+     any filters on unacceptable dates should examine the other
+     outputs.
+     """
+
+     cdef int length = len(djm)
+     cdef np.ndarray iy_out = np.empty(length, dtype=np.int)
+     cdef np.ndarray im_out = np.empty(length, dtype=np.int)
+     cdef np.ndarray id_out = np.empty(length, dtype=np.int)
+     cdef np.ndarray frac_out = np.empty(length, dtype=np.int)
+     cdef int output[4]
+     cdef int flag
+
+     for ii in range(length):
+          cpal.palDjcal(ndp, djm[ii], output, &flag)
+          if flag==0:
+              iy_out[ii] = output[0]
+              im_out[ii] = output[1]
+              id_out[ii] = output[2]
+              frac_out[ii] = output[3]
+          else:
+              iy_out[ii] = -1
+              im_out[ii] = -1
+              id_out[ii] = -1
+              frac_out[ii] = -1
+
+     return (iy_out, im_out, id_out, frac_out)
+
 def djcl( double djm ):
      """
      (iy, im, id, frac) = djcl( djm )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1799,8 +1799,8 @@ def fk5hz( double r5, double d5, double epoch):
      cpal.palFk5hz( r5, d5, epoch, &rh, &dh )
      return (rh, dh)
 
-def fk5hzVector(np.ndarray[double, ndim=1] r5,
-                np.ndarray[double, ndim=1] d5,
+def fk5hzVector(np.ndarray[double, ndim=1] r5 not None,
+                np.ndarray[double, ndim=1] d5 not None,
                 double epoch):
     """
     (rh, dh) = fk5hzVector(r5, d5, epoch)
@@ -1818,10 +1818,10 @@ def fk5hzVector(np.ndarray[double, ndim=1] r5,
 
     if len(d5)!=length:
         raise ValueError("You did not pass the same number of " \
-                         "RAs as Decs to fk5hzVector")
+                         + "RAs as Decs to fk5hzVector")
 
-    cdef np.ndarray ra_out = np.ndarray(length, dtype=np.float64)
-    cdef np.ndarray dec_out = np.ndarray(length, dtype=np.float64)
+    cdef np.ndarray ra_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray dec_out = np.empty(length, dtype=np.float64)
     cdef double rh
     cdef double dh
 

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2538,7 +2538,11 @@ def gmst( double ut1 ):
 
 def gmstVector(np.ndarray ut1):
      """
-     this is gmst, except that it accepts and returns vectors
+     t = gmstVector( ut1 )
+
+     where ut1 and t are both numpy arrays
+
+     @palGmst@
      """
      cdef int length = len(ut1)
      cdef np.ndarray gmout = np.zeros(length, dtype=np.float64)

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -154,6 +154,46 @@ def ampqk( double ra, double da, np.ndarray[double, ndim=1] amprms not None ):
      cpal.palAmpqk( ra, da, camprms, &rm, &dm )
      return (rm, dm)
 
+
+def ampqkVector(np.ndarray[double, ndim=1] ra not None,
+                np.ndarray[double, ndim=1] dec not None,
+                np.ndarray[double, ndim=1] amprms not None):
+     """
+     (rm, dm) = ampqkVector( ra, dec, amprms )
+
+     where ra, dec, rm, and dm are all numpy arrays
+
+     @palAmpqk@
+
+     Raises
+     ------
+     ValueError if input arrays of RA and Dec are not of the same
+     length
+     """
+
+     cdef int length = len(ra)
+
+     if len(dec)!=length:
+         raise ValueError("You did not pass as many Decs as RAs to " \
+                          + "ampqkVector")
+
+     cdef np.ndarray rm_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray dm_out = np.empty(length, dtype=np.float64)
+
+     cdef double rm
+     cdef double dm
+     cdef double camprms[21]
+
+     for ii in range(21):
+          camprms[ii] = amprms[ii]
+
+     for ii in range(length):
+          cpal.palAmpqk(ra[ii], dec[ii], camprms, &rm, &dm)
+          rm_out[ii] = rm
+          dm_out[ii] = dm
+
+     return (rm_out, dm_out)
+
 def aop( double rap, double dap, double date, double dut,
          double elongm, double phim, double hm, double xp,
          double yp, double tdk, double pmb, double rh,

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1297,7 +1297,7 @@ def dtf2d( int ihour, int imin, double sec ):
      else:
           bad = ""
           if j==1:
-               bad = "Degree argument outside range 0-369"
+               bad = "Hour argument outside range 0-23"
           elif j==2:
                bad = "Minute argument outside range 0-59"
           else:

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -2957,7 +2957,7 @@ def paVector(np.ndarray[double, ndim=1] ha not None,
              np.ndarray[double, ndim=1] dec not None,
              double phi):
      """
-     a = pa( ha, dec, phi )
+     a = paVector( ha, dec, phi )
 
      where ha, dec, and a are all numpy arrays
 

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1659,6 +1659,40 @@ def eqecl( double dr, double dd, double date ):
      cpal.palEqecl( dr, dd, date, &dl, &db )
      return (dl, db)
 
+def eqeclVector(np.ndarray[double, ndim=1] dr not None,
+                np.ndarray[double, ndim=1] dd not None,
+                double date):
+    """
+    (dl, db) = eqeclVector(dr, dd, date)
+
+    where dr, dd, dl, and db are all numpy arrays
+
+    @palEqEcl@
+
+    Raises
+    ------
+    ValueError if input arrays have different lengths
+    """
+
+    cdef int length = len(dr)
+
+    if len(dd)!=length:
+        raise ValueError("You did not pass the same number of Decs " \
+                         + "as RAs to eqeclVector")
+
+    cdef np.ndarray dl_out = np.empty(length, dtype=np.float64)
+    cdef np.ndarray db_out = np.empty(length, dtype=np.float64)
+
+    cdef double dl
+    cdef double db
+
+    for ii in range(length):
+        cpal.palEqecl(dr[ii], dd[ii], date, &dl, &db)
+        dl_out[ii] = dl
+        db_out[ii] = db
+
+    return (dl_out, db_out)
+
 def eqeqx( double date ):
      """
      eq = eqeqx( date )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1014,6 +1014,34 @@ def dr2af( int ndp, double angle ):
      sign = csign.decode('UTF-8')
      return ( sign, idmsf[0], idmsf[1], idmsf[2], idmsf[3] )
 
+def dr2afVector( int ndp, np.ndarray[double, ndim=1] angle not None):
+    """
+    (sign, id, im, is, frac) = dr2af( ndp, angle)
+
+    where angle is a numpy array of angles in radians
+    and all outputs are numpy arrays of the same size
+
+    @palDr2af@
+    """
+    cdef int length = len(angle)
+    cdef np.ndarray sign_out = np.ndarray(length, dtype=(unicode, 1))
+    cdef np.ndarray id_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray im_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray isec_out = np.ndarray(length, dtype=int)
+    cdef np.ndarray frac_out = np.ndarray(length, dtype=int)
+    cdef char * csign = " "
+    cdef int idmsf[4]
+
+    for ii in range(length):
+        cpal.palDr2af(ndp, angle[ii], csign, idmsf)
+        sign_out[ii] = csign.decode('UTF-8')
+        id_out[ii] = idmsf[0]
+        im_out[ii] = idmsf[1]
+        isec_out[ii] = idmsf[2]
+        frac_out[ii] = idmsf[3]
+
+    return (sign_out, id_out, im_out, isec_out, frac_out)
+
 def dr2tf( int ndp, double angle ):
      """
      (sign, ih, im, is, frac) = dr2tf( ndp, angle )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -72,6 +72,21 @@ def airmas( double zd ):
      """
      return cpal.palAirmas( zd )
 
+def airmasVector(np.ndarray[double, ndim=1] zd not None):
+     """
+     airmass = airmas( zd )
+
+     where zd and airmass are numpy arrays
+
+     @palAirmas@
+     """
+     cdef int length = len(zd)
+     cdef np.ndarray airmass_out = np.empty(length, dtype=np.float64)
+     for ii in range(length):
+         airmass_out[ii] = cpal.palAirmas(zd[ii])
+     return airmass_out
+
+
 def altaz(double ha, double dec, double phi):
      """
      (az, azd, azdd, el, eld, eldd, pa, pad, padd) = altaz( ha, dec, phi )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1371,6 +1371,49 @@ def dtf2r( int ihour, int imin, double sec ):
                bad = "Arcsec argument outside range 0-59.9999..."
           raise ValueError( bad )
 
+def dtf2rVector(np.ndarray[long, ndim=1] ihour, np.ndarray[long, ndim=1] imin,
+                np.ndarray[double, ndim=1] sec):
+    """
+    rad = dtf2rVector(ihour, imin, sec)
+
+    where ihour, imin, sec, and rad are all numpy arrays
+
+    @palDtf2r@
+
+    Raises
+    ------
+    ValueError if input arrays do not have the same length
+
+    If bad values (ihour outside of 0-23, imin outside of 0-59,
+    sec outside of 0-59.999999) are passed in, these result in
+    numpy.NaNs in the output.
+    """
+
+    cdef int length = len(ihour)
+
+    if len(imin)!=length:
+        raise ValueError("In dtf2rVector, imin does not have the same length " \
+                         + "as ihour")
+
+    if len(sec)!=length:
+        raise ValueError("In dtf2rVector, sec does not have the same length " \
+                         + "as ihour")
+
+    cdef np.ndarray radians = np.empty(length, dtype=np.float64)
+    cdef int flag
+    cdef double value
+
+    for ii in range(length):
+        cpal.palDtf2r( ihour[ii], imin[ii], sec[ii], &value, &flag )
+        if flag==0:
+            radians[ii] = value
+        else:
+            radians[ii] = np.NaN
+
+    return radians
+
+
+
 def dtp2s( double xi, double eta, double raz, double decz):
      """
      (ra,dec) = dtp2s( xi, eta, raz, decz )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1095,6 +1095,20 @@ def drange( double angle ):
      """
      return cpal.palDrange( angle )
 
+def drangeVector(np.ndarray[double, ndim=1] angle not None):
+     """
+     a = drange(angle)
+
+     where angle and a are numpy arrays
+
+     @palDrange@
+     """
+     cdef int length = len(angle)
+     cdef np.ndarray angle_out = np.empty(length, dtype=np.float64)
+     for ii in range(length):
+         angle_out[ii] = cpal.palDrange(angle[ii])
+     return angle_out
+
 def dranrm( double angle ):
      """
      a = dranrm( angle )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -74,7 +74,7 @@ def airmas( double zd ):
 
 def airmasVector(np.ndarray[double, ndim=1] zd not None):
      """
-     airmass = airmas( zd )
+     airmass = airmasVector( zd )
 
      where zd and airmass are numpy arrays
 
@@ -109,7 +109,7 @@ def altazVector(np.ndarray[double, ndim=1] ha not None,
                 np.ndarray[double, ndim=1] dec not None,
                 double phi):
      """
-     (az, azd, azdd, el, eld, eldd, pa, pad, padd) = altaz( ha, dec, phi )
+     (az, azd, azdd, el, eld, eldd, pa, pad, padd) = altazVector( ha, dec, phi )
 
      where ha, dec and all outputs are numpy arrays
 
@@ -302,7 +302,7 @@ def aopqkVector(np.ndarray[double, ndim=1] rap not None,
                 np.ndarray[double, ndim=1] dap not None,
                 np.ndarray[double, ndim=1] aoprms not None):
     """
-    (aob, zob, hob, dob, rob) = aopqk( rap, dap, aoprms )
+    (aob, zob, hob, dob, rob) = aopqkVector( rap, dap, aoprms )
 
     where rap, dap and all outputs are numpy arrays
 
@@ -613,7 +613,7 @@ def daf2rVector(np.ndarray[long, ndim=1] ideg_in not None,
                 np.ndarray[long, ndim=1] iamin_in not None,
                 np.ndarray[double, ndim=1] asec_in not None):
     """
-    ang = daf2r( ideg, iamin, asec)
+    ang = daf2rVector( ideg, iamin, asec)
 
     where ideg, iamin, and asec are numpy arrays of degrees,
     minutes, and seconds.  ideg and iamin are arrays of ints.  asec
@@ -764,7 +764,7 @@ def dd2tf( int ndp, double days ):
 
 def dd2tfVector( int ndp, np.ndarray[double, ndim=1] days not None):
     """
-    (sign, ih, im, is ,frac) = ddtf( ndp, dayList)
+    (sign, ih, im, is ,frac) = ddtfVector( ndp, dayList)
 
     where ndp is an integer denoting the resolution to which the
     fraction of seconds should be taken and dayList is a numpy
@@ -810,7 +810,7 @@ def de2hVector( np.ndarray[double, ndim=1] ha not None,
                 np.ndarray[double, ndim=1] dec not None,
                 double phi ):
      """
-     (az, el) = de2h( ha, dec, phi )
+     (az, el) = de2hVector( ha, dec, phi )
 
      where ha, dec, az, and el are numpy arrays
 
@@ -872,7 +872,7 @@ def dh2eVector(np.ndarray[double, ndim=1] az not None,
                np.ndarray[double, ndim=1] el not None,
                double phi):
      """
-     (ha, dec) = dh2e( az, el, phi)
+     (ha, dec) = dh2eVector( az, el, phi)
 
      where az, el, ha, and dec are all numpy arrays
 
@@ -1087,7 +1087,7 @@ def dmoon( double date ):
 
 def dmoonVector(np.ndarray[double, ndim=1] date):
      """
-     (x, y, z, xd, yd, zd) = dmoon(date)
+     (x, y, z, xd, yd, zd) = dmoonVector(date)
 
      where date and all of the outputs are numpy arrays
 
@@ -1346,7 +1346,7 @@ def drange( double angle ):
 
 def drangeVector(np.ndarray[double, ndim=1] angle not None):
      """
-     a = drange(angle)
+     a = drangeVector(angle)
 
      where angle and a are numpy arrays
 
@@ -1407,7 +1407,7 @@ def ds2tpVector( np.ndarray[double, ndim=1] ra not None,
                  np.ndarray[double, ndim=1] dec not None,
                  double raz, double decz ):
      """
-     (xi, eta) = ds2tp( ra, dec, raz, decz )
+     (xi, eta) = ds2tpVector( ra, dec, raz, decz )
 
      @palDs2tp@
 
@@ -1452,7 +1452,7 @@ def dsep( double a1, double b1, double a2, double b2 ):
 
 def dsepVector(np.ndarray a1, np.ndarray b1, np.ndarray a2, np.ndarray b2):
      """
-     s = dsep( a1, b1, a2, b2 )
+     s = dsepVector( a1, b1, a2, b2 )
 
      where a1, b1, a2, b2, and s are numpy arrays
 

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -1425,6 +1425,42 @@ def dtp2s( double xi, double eta, double raz, double decz):
      cpal.palDtp2s( xi, eta, raz, decz, &ra, &dec )
      return (ra,dec)
 
+def dtp2sVector(np.ndarray[double, ndim=1] xi not None,
+                np.ndarray[double, ndim=1] eta not None,
+                double raz, double decz):
+     """
+     (ra, dec) = dtp2sVector( xi, eta, raz, decz)
+
+     where xi, eta, ra, and dex (NOT raz, decz) are numpy arrays
+
+     @palDtp2s@
+
+     Raises
+     ------
+     ValueError if input arrays are of different lengths
+     """
+
+     cdef int length = len(xi)
+
+     if len(eta)!=length:
+          raise ValueError("The arrays of tangent plane coordinates " \
+                           + "you passed to dtp2sVector are of " \
+                           + "different lengths")
+
+     cdef np.ndarray ra_out = np.empty(length, dtype=np.float64)
+     cdef np.ndarray dec_out = np.empty(length, dtype=np.float64)
+
+     cdef double ra
+     cdef double dec
+
+     for ii in range(length):
+         cpal.palDtp2s(xi[ii], eta[ii], raz, decz, &ra, &dec)
+         ra_out[ii] = ra
+         dec_out[ii] = dec
+
+     return (ra_out, dec_out)
+
+
 def dtps2c( double xi, double eta, double ra, double dec ):
      """
      (raz1, decz1, raz2, decz2) = dtps2c( xi, eta, ra, dec )

--- a/pal.pyx.in
+++ b/pal.pyx.in
@@ -105,13 +105,26 @@ def altaz(double ha, double dec, double phi):
      cpal.palAltaz (ha, dec, phi, &az, &azd, &azdd, &el, &eld, &eldd, &pa, &pad, &padd )
      return (az, azd, azdd, el, eld, eldd, pa, pad, padd )
 
-def altazVector(np.ndarray ha, np.ndarray dec, double phi):
+def altazVector(np.ndarray[double, ndim=1] ha not None,
+                np.ndarray[double, ndim=1] dec not None,
+                double phi):
      """
-     This is just altaz, except that it accepts vectors of hour angle and declination.
-     Latitude is still a float.
-     All outputs are vectors.
+     (az, azd, azdd, el, eld, eldd, pa, pad, padd) = altaz( ha, dec, phi )
+
+     where ha, dec and all outputs are numpy arrays
+
+     @palAltaz@
+
+     Raises
+     ------
+     ValueError if input numpy arrays are not of the same length
      """
      cdef int length = len(ha)
+
+     if len(dec)!=length:
+         raise ValueError("You did not pass as many Decs as " \
+                           + "Hour Angles to altazVector")
+
      cdef np.ndarray azout = np.zeros(length, dtype=np.float64)
      cdef double az
      cdef np.ndarray azdout = np.zeros(length, dtype=np.float64)

--- a/test_pal.py
+++ b/test_pal.py
@@ -1838,6 +1838,38 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(r1,r2,12)
             self.assertAlmostEqual(d1,d2,12)
 
+        # test that an exception is raised if the input arrays
+        # are of inconsistent shapes
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkVector(raIn, decIn[:10], pmr, pmd, px, rv, amprms)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into mapqkVector are " \
+                         + "not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkVector(raIn, decIn, pmr[:10], pmd, px, rv, amprms)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into mapqkVector are " \
+                         + "not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkVector(raIn, decIn, pmr, pmd[:10], px, rv, amprms)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into mapqkVector are " \
+                         + "not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkVector(raIn, decIn, pmr, pmd, px[:10], rv, amprms)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into mapqkVector are " \
+                         + "not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkVector(raIn, decIn, pmr, pmd, px, rv[:10], amprms)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into mapqkVector are " \
+                         + "not of the same length")
+
     def test_moon(self):
         expected = np.array( [
              0.00229161514616454,

--- a/test_pal.py
+++ b/test_pal.py
@@ -1619,6 +1619,25 @@ class TestPAL(unittest.TestCase) :
         pv = pal.dmoon( 48634.4687174074 )
         np.testing.assert_array_almost_equal( pv, expected, decimal=12 )
 
+
+    def test_dmoonVector(self):
+       """
+       Test that dmoonVector returns results consistent with dmoon
+       """
+       np.random.seed(141)
+       nSamples = 1000
+       date = np.random.random_sample(nSamples)*10000.0 + 43000.0
+       testX, testY, testZ, testXd, testYd, testZd = pal.dmoonVector(date)
+
+       for ii in range(nSamples):
+           x, y, z, xd, yd, zd = pal.dmoon(date[ii])
+           self.assertEqual(x, testX[ii])
+           self.assertEqual(y, testY[ii])
+           self.assertEqual(z, testZ[ii])
+           self.assertEqual(xd, testXd[ii])
+           self.assertEqual(yd, testYd[ii])
+           self.assertEqual(zd, testZd[ii])
+
     def test_nut(self):
         expected = np.array( [
             [  9.999999969492166e-1, 7.166577986249302e-5,  3.107382973077677e-5 ],

--- a/test_pal.py
+++ b/test_pal.py
@@ -236,6 +236,13 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(d1,d2,12)
             self.assertAlmostEqual(r1,r2,12)
 
+        with self.assertRaises(ValueError) as context:
+            results = pal.aopqkVector(raIn[:6], decIn, obsrms)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of Decs as RAs " \
+                         + "to aopqkVector")
+
+
     def test_aop(self):
         dap = -0.1234
         date = 51000.1

--- a/test_pal.py
+++ b/test_pal.py
@@ -447,6 +447,27 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( seconds, 13 )
         self.assertEqual( fraction, 3333 )
 
+    def test_dd2tfVector(self):
+        """
+        Test that dd2tfVector gives the same results as dd2tf
+        """
+        np.random.seed(126)
+        nSamples = 100
+        daysList = (np.random.sample(nSamples)-0.5)*1200.0
+
+        for ndp in [2, 3, 4, 5]:
+            testSign, testIh, testIm, testIs, testFrac = pal.dd2tfVector(ndp, daysList)
+            for ix, days in enumerate(daysList):
+                controlSign, controlIh,\
+                controlIm, controlIs,\
+                controlFrac = pal.dd2tf(ndp, days)
+
+                self.assertEqual(controlSign, testSign[ix])
+                self.assertEqual(controlIm, testIm[ix])
+                self.assertEqual(controlIs, testIs[ix])
+                self.assertEqual(controlFrac, testFrac[ix])
+
+
     def test_cldj(self):
         d = pal.cldj( 1899, 12, 31 )
         self.assertEqual( d, 15019 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -910,6 +910,31 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dl, 0.7036566430349022, 6 )
         self.assertAlmostEqual( db, -0.4036047164116848, 6 )
 
+    def test_eqeclVector(self):
+        """
+        Test that eqeclVector produces results consistent with
+        eqecl
+        """
+        mjd = 53000.0
+        np.random.seed(137)
+        nSamples = 200
+        ra = np.random.random_sample(nSamples)*2.0*np.pi
+        dec = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        testDb, testDl = pal.eqeclVector(ra, dec, mjd)
+        for ii in range(nSamples):
+            controlDb, controlDl = pal.eqecl(ra[ii], dec[ii], mjd)
+            self.assertEqual(controlDb, testDb[ii])
+            self.assertEqual(controlDl, testDl[ii])
+
+        # test that an exception is raised if inpu arrays are of
+        # different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.eqeclVector(ra, dec[:8], mjd)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of Decs " \
+                         + "as RAs to eqeclVector")
+
     def test_eqeqx(self):
         self.assertAlmostEqual( pal.eqeqx( 53736 ), -0.8834195072043790156e-5, 15 )
 

--- a/test_pal.py
+++ b/test_pal.py
@@ -960,6 +960,32 @@ class TestPAL(unittest.TestCase) :
                          "You did not pass the same number of " \
                          "RAs as Decs to fk5hzVector")
 
+    def test_hkf5zVector(self):
+        """
+        Test that hkf5zVector produces results consistent with
+        hkf5z
+        """
+        np.random.seed(133)
+        nSamples = 200
+        raList = np.random.random_sample(nSamples)*2.0*np.pi
+        decList = (np.random.random_sample(nSamples)-0.5)*np.pi
+        testRa, testDec, testDr, testDd = pal.hfk5zVector(raList, decList, 2000.0)
+        for ii in range(nSamples):
+            controlRa, controlDec, \
+            controlDr, controlDd = pal.hfk5z(raList[ii], decList[ii], 2000.0)
+            self.assertEqual(testRa[ii], controlRa)
+            self.assertEqual(testDec[ii], controlDec)
+            self.assertEqual(testDr[ii], controlDr)
+            self.assertEqual(testDd[ii], controlDd)
+
+        # test that an exception is raised if raList and decList are
+        # of different lengths
+        with self.assertRaises(ValueError) as context:
+            ra, dec, dr, dd = pal.hfk5zVector(raList, decList[:77], 2000.0)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of RAs as " \
+                         + "Decs to hfk5zVector")
+
 
     def test_fk54z(self):
         (r1950, d1950, dr1950, dd1950) = pal.fk54z( 1.2, -0.3, 1960 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -656,6 +656,52 @@ class TestPAL(unittest.TestCase) :
         self.assertRaises( ValueError, pal.dtf2r, 23, -1, 32 )
         self.assertRaises( ValueError, pal.dtf2r, 23, 1, 60 )
 
+    def test_dtf2rVector(self):
+        """
+        Test that dtf2rVector gives results consistent with
+        dtf2r
+        """
+        np.random.seed(131)
+        nSamples = 100
+        iHour = np.random.random_integers(0, 23, nSamples)
+        iMin = np.random.random_integers(0, 59, nSamples)
+        sec = np.random.random_sample(nSamples)*60.0
+
+        testRad = pal.dtf2rVector(iHour, iMin, sec)
+        for ii in range(nSamples):
+            controlRad = pal.dtf2r(iHour[ii], iMin[ii], sec[ii])
+            self.assertEqual(testRad[ii], controlRad)
+            self.assertFalse(np.isnan(testRad[ii]))
+
+        # test that NaN's are produced when bad inputs are given
+        iHour[5] = 24
+        iMin[7] = 60
+        sec[19] = 60.001
+        testRad = pal.dtf2rVector(iHour, iMin, sec)
+        for ii in range(nSamples):
+            if ii!=5 and ii!=7 and ii!=19:
+                controlRad = pal.dtf2r(iHour[ii], iMin[ii], sec[ii])
+                self.assertEqual(testRad[ii], controlRad)
+                self.assertFalse(np.isnan(testRad[ii]))
+            else:
+                self.assertTrue(np.isnan(testRad[ii]))
+
+        # test that exceptions are raised when you pass in
+        # mis-matched input arrays
+        with self.assertRaises(ValueError) as context:
+            testRad = pal.dtf2rVector(iHour, iMin[:19], sec)
+        self.assertEqual(context.exception.message,
+                         "In dtf2rVector, imin does not have the " \
+                         + "same length as ihour")
+
+        with self.assertRaises(ValueError) as context:
+            testRad = pal.dtf2rVector(iHour, iMin, sec[:19])
+        self.assertEqual(context.exception.message,
+                         "In dtf2rVector, sec does not have the " \
+                         + "same length as ihour")
+
+
+
     def test_dat(self):
         self.assertEqual( pal.dat( 43900 ), 18 )
         self.assertAlmostEqual( pal.dtt( 40404 ), 39.709746, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -1413,6 +1413,34 @@ class TestPAL(unittest.TestCase) :
     def test_ranorm(self):
         self.assertAlmostEqual( pal.dranrm( -0.1 ), 6.183185307179587, 12 )
 
+    def test_dranrmVector(self):
+        """
+        Test that dranrmVector returns the same results as dranrm
+        """
+        np.random.seed(74310)
+        nSamples = 100
+        angle_in = (np.random.random_sample(100)-0.5)*4.0*np.pi
+        angle_in = np.array([aa + 2.0*np.pi if aa>0.0 else aa for aa in angle_in])
+
+        # make sure we created input angles that are outside the
+        # 0 to 2pi range
+        for aa in angle_in:
+            if aa>0.0 and aa<2.0*np.pi:
+                raise RuntimeError("did not create correct inputs for test_dranrmVector")
+
+        testAngle = pal.dranrmVector(angle_in)
+
+        # verify that the resulting angles are equivalent to the input
+        # angles normalized to the 0-2pi ranges
+        self.assertTrue(testAngle.min()>0.0)
+        self.assertTrue(testAngle.max()<2.0*np.pi)
+        np.testing.assert_array_almost_equal(np.cos(testAngle), np.cos(angle_in), 9)
+        np.testing.assert_array_almost_equal(np.sin(testAngle), np.sin(angle_in), 9)
+
+        for ii in range(nSamples):
+            controlAngle = pal.dranrm(angle_in[ii])
+            self.assertEqual(controlAngle, testAngle[ii])
+
     def test_ref(self):
         self.assertAlmostEqual( pal.refro(1.4, 3456.7, 280, 678.9, 0.9, 0.55,
                                 -0.3, 0.006, 1e-9 ),

--- a/test_pal.py
+++ b/test_pal.py
@@ -368,7 +368,7 @@ class TestPAL(unittest.TestCase) :
             self.assertFalse(np.isnan(paControl))
 
         # test the case where we only feed one point in as v2
-        testPa = pal.dpavVector(v1, v2[4:5])
+        testPa = pal.dpavVector(v1, v2[4])
         for ii in range(nSamples):
             paControl = pal.dpav(v1[ii], v2[4])
             self.assertEqual(paControl, testPa[ii])
@@ -379,7 +379,7 @@ class TestPAL(unittest.TestCase) :
             testPa = pal.dpavVector(v1, v2[:19])
         self.assertEqual(context.exception.message,
                          "In dpavVector, v2 must either be a numpy array of " \
-                         + "shape (1, 3) or a numpy array of shape (n, 3) "\
+                         + "shape (3,) or a numpy array of shape (n, 3) "\
                          + "where n is the number of rows in v1")
 
         v3 = np.random.random_sample((nSamples, 6))
@@ -396,6 +396,12 @@ class TestPAL(unittest.TestCase) :
                          "In dpavVector, v2 must be a numpy array in which " \
                          + "each row has 3 elements. " \
                          + "Your rows have 6 elements.")
+
+        with self.assertRaises(ValueError) as context:
+            testPa = pal.dpavVector(v1, np.random.random_sample(9))
+        self.assertEqual(context.exception.message,
+                         "The v2 you passed into dpavVector represents a single " \
+                         "point with 9 elements; it should have 3 elements")
 
     def test_caldj(self):
         djm = pal.caldj( 1999, 12, 31 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -322,19 +322,19 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raied when the numpy arrays are of
         # incorrect size
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in[:9], a2_in, b2_in)
         self.assertEqual(context.exception.message,
                          "The first two arguments of dbearVector must " \
                          + "be numpy arrays with the same number of elements")
 
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in, a2_in, b2_in[:8])
         self.assertEqual(context.exception.message,
                          "The second two arguments of dbearVector must " \
                          + "be numpy arrays with the same number of elements")
 
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in, a2_in[:9], b2_in[:9])
         self.assertEqual(context.exception.message,
                          "The second two arguments of dbearVector must " \
@@ -402,7 +402,7 @@ class TestPAL(unittest.TestCase) :
         # test that an exception is raised if you don't pass in
         # 3-D cartesian points
         dummyData = np.random.random_sample((20, 5))*10.0
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             aTest, bTest = pal.dcc2sVector(dummyData)
         self.assertEqual(context.exception.message,
                          "The input to dcc2sVector should be " \
@@ -432,7 +432,7 @@ class TestPAL(unittest.TestCase) :
         np.testing.assert_array_almost_equal(np.sin(dec), np.sin(bTest), 9)
 
         # test that an exception is raised if you pass in arrays of different lengths
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             vTest = pal.dcs2cVector(ra, dec[:16])
         self.assertEqual(context.exception.message,
                          "You did not pass as many latitudes as longitudes " \
@@ -983,7 +983,7 @@ class TestPAL(unittest.TestCase) :
 
         # make sure that an exceptoion is raised if you pass in
         # mismatched x and y vectors
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             xTestList, yTestLIst = pal.pcdVector(disco, x_in, y_in[:10])
         self.assertEqual(context.exception.message,
                          "You did not pass the same number of x as y " \
@@ -1022,7 +1022,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if you pass in different numbers
         # of x and y coordinates
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             xTestList, yTestList = pal.unpcdVector(disco, x_in, y_in[:30])
         self.assertEqual(context.exception.message,
                          "You did not pass the same number of x as y " \

--- a/test_pal.py
+++ b/test_pal.py
@@ -2266,6 +2266,38 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(r1,r2,12)
             self.assertAlmostEqual(d1,d2,12)
 
+        # test that an exception is raised if input arrays are of
+        # inconsistent length
+        with self.assertRaises(ValueError) as context:
+            results = pal.pmVector(raIn, decIn[:3], pmr, pmd, px, rv, ep0, ep1)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into pmVector are not all of " \
+                         + "the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.pmVector(raIn, decIn, pmr[:3], pmd, px, rv, ep0, ep1)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into pmVector are not all of " \
+                         + "the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.pmVector(raIn, decIn, pmr, pmd[:3], px, rv, ep0, ep1)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into pmVector are not all of " \
+                         + "the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.pmVector(raIn, decIn, pmr, pmd, px[:3], rv, ep0, ep1)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into pmVector are not all of " \
+                         + "the same length")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.pmVector(raIn, decIn, pmr, pmd, px, rv[:3], ep0, ep1)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into pmVector are not all of " \
+                         + "the same length")
+
     def test_polmo(self):
         (elong, phi, daz) = pal.polmo( 0.7, -0.5, 1.0e-6, -2.0e-6)
 

--- a/test_pal.py
+++ b/test_pal.py
@@ -2014,6 +2014,23 @@ class TestPAL(unittest.TestCase) :
     def test_range(self):
         self.assertAlmostEqual( pal.drange( -4 ), 2.283185307179586, 12 )
 
+    def test_drangeVector(self):
+        """
+        Test that drangeVector returns results consistent with drange
+        """
+        np.random.seed(140)
+        nSamples = 1000
+        angle_in = np.random.random_sample(nSamples)*10.0*np.pi+2.0*np.pi
+        angle_in = np.append(angle_in, np.random.random_sample(nSamples)*(-10.0)*np.pi)
+
+        test_angle = pal.drangeVector(angle_in)
+
+        for ii in range(len(angle_in)):
+            control_angle = pal.drange(angle_in[ii])
+            self.assertEqual(control_angle, test_angle[ii])
+            self.assertAlmostEqual(np.sin(angle_in[ii]), np.sin(test_angle[ii]), 10)
+            self.assertAlmostEqual(np.cos(angle_in[ii]), np.cos(test_angle[ii]), 10)
+
     def test_ranorm(self):
         self.assertAlmostEqual( pal.dranrm( -0.1 ), 6.183185307179587, 12 )
 

--- a/test_pal.py
+++ b/test_pal.py
@@ -615,39 +615,38 @@ class TestPAL(unittest.TestCase) :
         iMin = np.random.random_integers(0, 59, nSamples)
         sec = np.random.random_sample(nSamples)*60.0
 
-        testRad = pal.dtf2dVector(iHour, iMin, sec)
+        testDays = pal.dtf2dVector(iHour, iMin, sec)
         for ii in range(nSamples):
-            controlRad = pal.dtf2d(iHour[ii], iMin[ii], sec[ii])
-            self.assertEqual(testRad[ii], controlRad)
-            self.assertFalse(np.isnan(testRad[ii]))
+            controlDays = pal.dtf2d(iHour[ii], iMin[ii], sec[ii])
+            self.assertEqual(testDays[ii], controlDays)
+            self.assertFalse(np.isnan(testDays[ii]))
 
         # test that NaN's are produced when bad inputs are given
         iHour[5] = 24
         iMin[7] = 60
         sec[19] = 60.001
-        testRad = pal.dtf2dVector(iHour, iMin, sec)
+        testDays = pal.dtf2dVector(iHour, iMin, sec)
         for ii in range(nSamples):
             if ii!=5 and ii!=7 and ii!=19:
-                controlRad = pal.dtf2d(iHour[ii], iMin[ii], sec[ii])
-                self.assertEqual(testRad[ii], controlRad)
-                self.assertFalse(np.isnan(testRad[ii]))
+                controlDays = pal.dtf2d(iHour[ii], iMin[ii], sec[ii])
+                self.assertEqual(testDays[ii], controlDays)
+                self.assertFalse(np.isnan(testDays[ii]))
             else:
-                self.assertTrue(np.isnan(testRad[ii]))
+                self.assertTrue(np.isnan(testDays[ii]))
 
         # test that exceptions are raised when you pass in
         # mis-matched input arrays
         with self.assertRaises(ValueError) as context:
-            testRad = pal.dtf2dVector(iHour, iMin[:19], sec)
+            testDays = pal.dtf2dVector(iHour, iMin[:19], sec)
         self.assertEqual(context.exception.message,
                          "In dtf2dVector, imin does not have the " \
                          + "same length as ihour")
 
         with self.assertRaises(ValueError) as context:
-            testRad = pal.dtf2dVector(iHour, iMin, sec[:19])
+            testDays = pal.dtf2dVector(iHour, iMin, sec[:19])
         self.assertEqual(context.exception.message,
                          "In dtf2dVector, sec does not have the " \
                          + "same length as ihour")
-
 
 
     def test_dtf2r(self):

--- a/test_pal.py
+++ b/test_pal.py
@@ -1951,6 +1951,36 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dl, 3.798775860769474, 12 )
         self.assertAlmostEqual( db,  -0.1397070490669407, 12 )
 
+    def test_supgalVector(self):
+        """
+        Test that supgalVector returns results consistent with supgal
+        """
+
+        np.random.seed(134)
+        nSamples = 200
+        dslList = np.random.random_sample(nSamples)*2.0*np.pi
+        dsbList = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        testDl, testDb = pal.supgalVector(dslList, dsbList)
+
+        for ii in range(nSamples):
+            controlDl, controlDb = pal.supgal(dslList[ii], dsbList[ii])
+            self.assertEqual(controlDl, testDl[ii])
+            self.assertEqual(controlDb, testDb[ii])
+
+        # test that supgalVector and galsupVector invert each other
+        testDsl, testDsb = pal.galsupVector(testDl, testDb)
+        np.testing.assert_array_almost_equal(testDsl, dslList, 9)
+        np.testing.assert_array_almost_equal(testDsb, dsbList, 9)
+
+        # test that an exception is raised if the input arrays are of
+        # different length
+        with self.assertRaises(ValueError) as context:
+            testDl, testDb = pal.supgalVector(dslList[:16], dsbList)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         + "longitudes as latitudes into supgalVector")
+
     def test_tp(self):
         dr0 = 3.1
         dd0 = -0.9

--- a/test_pal.py
+++ b/test_pal.py
@@ -342,6 +342,61 @@ class TestPAL(unittest.TestCase) :
                          + "as the first two arguments, or they must have " \
                          + "only one element")
 
+
+    def test_dpavVector(self):
+        """
+        Test that dpavVector is consistent with dpav
+        """
+        np.random.seed(127)
+        nSamples = 200
+        phi = np.random.random_sample(nSamples)*2.0*np.pi
+        theta = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        v1 = np.array([[np.cos(th), np.sin(th)*np.cos(ph), np.sin(th)*np.sin(ph)] \
+                        for th, ph in zip(theta, phi)])
+
+        phi = np.random.random_sample(nSamples)*2.0*np.pi
+        theta = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        v2 = np.array([[np.cos(th), np.sin(th)*np.cos(ph), np.sin(th)*np.sin(ph)] \
+                          for th, ph in zip(theta, phi)])
+
+        testPa = pal.dpavVector(v1, v2)
+        for ii in range(nSamples):
+            paControl = pal.dpav(v1[ii], v2[ii])
+            self.assertEqual(paControl, testPa[ii])
+            self.assertFalse(np.isnan(paControl))
+
+        # test the case where we only feed one point in as v2
+        testPa = pal.dpavVector(v1, v2[4:5])
+        for ii in range(nSamples):
+            paControl = pal.dpav(v1[ii], v2[4])
+            self.assertEqual(paControl, testPa[ii])
+            self.assertFalse(np.isnan(paControl))
+
+        # test that exceptions are raised when they should be
+        with self.assertRaises(ValueError) as context:
+            testPa = pal.dpavVector(v1, v2[:19])
+        self.assertEqual(context.exception.message,
+                         "In dpavVector, v2 must either be a numpy array of " \
+                         + "shape (1, 3) or a numpy array of shape (n, 3) "\
+                         + "where n is the number of rows in v1")
+
+        v3 = np.random.random_sample((nSamples, 6))
+        with self.assertRaises(ValueError) as context:
+            testPa = pal.dpavVector(v3, v2)
+        self.assertEqual(context.exception.message,
+                         "In dpavVector, v1 must be a numpy array in which " \
+                         + "each row has 3 elements. " \
+                         + "Your rows have 6 elements.")
+
+        with self.assertRaises(ValueError) as context:
+            testPa = pal.dpavVector(v1, v3)
+        self.assertEqual(context.exception.message,
+                         "In dpavVector, v2 must be a numpy array in which " \
+                         + "each row has 3 elements. " \
+                         + "Your rows have 6 elements.")
+
     def test_caldj(self):
         djm = pal.caldj( 1999, 12, 31 )
         self.assertEqual( djm, 51543 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -992,6 +992,123 @@ class TestPAL(unittest.TestCase) :
         np.testing.assert_allclose( dvh, vhex2, atol=1e-12 )
         np.testing.assert_allclose( dph, phex2, atol=1e-12 )
 
+    def test_fk524(self):
+        """
+        Test that fk524 gives results consistent with data published
+        in:
+
+        'Explanatory Supplement to The Astronomical Almanac'
+        Seidelmann, P. Kenneth (1992)
+        University Science Books
+
+        Table 3.58.1
+        """
+
+        # fk4 ra
+        hr_in = np.array([0, 3, 6, 14, 21, 1, 20, 11, 14])
+        min_in = np.array([17, 17, 11, 36, 4, 48, 15, 50, 54])
+        sec_in = np.array([28.774, 55.847, 43.975, 11.250, 39.935, \
+                           48.784, 3.004, 6.172, 59.224])
+
+        fk4_ra = pal.dtf2rVector(hr_in, min_in, sec_in)
+
+        # fk4 dec
+        sgn = np.array([-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 1.0])
+        deg_in = np.array([65, 43, 74, 60, 38, 89, 89, 38, 0])
+        amin_in = np.array([10, 15, 44, 37, 29, 1, 8, 4, 1])
+        asec_in = np.array([6.70, 35.74, 12.46, 48.85, 59.10, 43.74, 18.48, \
+                            39.15, 58.08])
+
+        fk4_dec = sgn*pal.daf2rVector(deg_in, amin_in, asec_in)
+
+        # fk4 mura
+        sgn = np.array([1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, 1.0 , 1.0])
+        hr_in = np.zeros(9, dtype=np.int)
+        min_in = np.zeros(9, dtype=np.int)
+        sec_in = np.array([27.141, 27.827, 3.105, 49.042, \
+                           35.227, 18.107, 11.702, 33.873, 0.411])
+
+        fk4_mura = 0.01*sgn*pal.dtf2rVector(hr_in, min_in, sec_in)
+
+        # fk4 mudec
+        radPerArcsec = np.radians(1.0/3600.0)
+        fk4_mudec = 0.01*radPerArcsec*np.array([116.74, 74.76, -21.12, 71.20, \
+                                         318.47, -0.43, -0.09, -580.57,
+                                         -2.73])
+
+        fk4_px = np.array([0.134, 0.156, 0.115, 0.751, 0.292, 0.000, \
+                           0.000, 0.116, 0.000])
+
+        fk4_vr = np.array([8.70, 86.80, 35.00, -22.20, -64.00, 0.00, \
+                           0.00, -98.30, 0.00])
+
+        # fk5 ra
+        hr_in = np.array([0, 3, 6, 14, 21, 2, 21, 11, 14])
+        min_in = np.array([20, 19, 10, 39, 6, 31, 8, 52, 57])
+        sec_in = np.array([4.3100, 55.6785, 14.5196, 36.1869, \
+                           54.5901, 49.8131, 46.0652, 58.7461, \
+                           33.2650])
+
+        fk5_ra = pal.dtf2rVector(hr_in, min_in, sec_in)
+
+        # fk5 dec
+        sgn = np.array([-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, -1.0, 1.0, -1.0])
+        deg_in = np.array([64, 43, 74, 60, 38, 89, 88, 37, 0])
+        amin_in = np.array([52, 4, 45, 50, 44, 15, 57, 43, 10])
+        asec_in = np.array([29.332, 10.830, 11.036, 7.393, 44.969, \
+                            50.661, 23.667, 7.456, 3.240])
+
+        fk5_dec = sgn*pal.daf2rVector(deg_in, amin_in, asec_in)
+
+        # fk5 mura
+        sgn = np.array([1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, 1.0 , 1.0])
+        hr_in = np.zeros(9, dtype=np.int)
+        min_in = np.zeros(9, dtype=np.int)
+        sec_in = np.array([26.8649, 27.7694, 3.1310, 49.5060, \
+                           35.3528, 21.7272, 8.4469, 33.7156, \
+                           0.4273])
+
+        fk5_mura = 0.01*sgn*pal.dtf2rVector(hr_in, min_in, sec_in)
+
+        # fk5 mudec
+        fk5_mudec = 0.01*radPerArcsec*np.array([116.285, 73.050, -21.304, \
+                                                69.934, 320.206, -1.571, \
+                                                0.171, -581.216, \
+                                                -2.402])
+
+        fk5_px = np.array([0.1340, 0.1559, 0.1150, 0.7516, \
+                           0.2923, 0.0000, 0.0000, \
+                           0.1161, 0.0000])
+
+        fk5_vr = np.array([8.74, 86.87, 35.00, -22.18, -63.89, 0.00, \
+                           0.00, -97.81, 0.00])
+
+        arcsecPerRad = np.degrees(1.0)*3600.0
+
+        for ra5, dec5, mura5, mudec5, px5, vr5, \
+            ra4, dec4, mura4, mudec4, px4, vr4 in \
+            zip(fk5_ra, fk5_dec, fk5_mura, fk5_mudec, fk5_px, fk5_vr, \
+                fk4_ra, fk4_dec, fk4_mura, fk4_mudec, fk4_px, fk4_vr):
+
+            ra, dec, mura, \
+            mudec, px, vr = pal.fk524(ra5, dec5, mura5, mudec5, px5, vr5)
+
+            # dpos is the angular separation (in arcsec) between
+            # the result of pal.fk524 and the true fk4 coordinates
+            # of the sample point
+            dpos = arcsecPerRad*pal.dsep(ra4, dec4, ra, dec)
+
+            dmura = arcsecPerRad*np.abs(mura-mura4)
+            dmudec = arcsecPerRad*np.abs(mudec-mudec4)
+            dpx = np.abs(px-px4)
+            dvr = np.abs(vr-vr4)
+
+            self.assertTrue(dpos<0.001)
+            self.assertTrue(dmura<0.01)
+            self.assertTrue(dmudec<0.01)
+            self.assertTrue(dpx<0.001)
+            self.assertTrue(dvr<0.01)
+
     def test_fk45z(self):
         (r2000, d2000) = pal.fk45z( 1.2, -0.3, 1960 )
         self.assertAlmostEqual( r2000, 1.2097812228966762227, 11 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -133,7 +133,7 @@ class TestPAL(unittest.TestCase) :
 
         with self.assertRaises(ValueError) as context:
             results = pal.altazVector(haIn[:10], decIn, phi)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many Decs as Hour Angles " \
                          + "to altazVector")
 
@@ -182,7 +182,7 @@ class TestPAL(unittest.TestCase) :
         # length
         with self.assertRaises(ValueError) as context:
             results = pal.ampqkVector(ra_in[:17], dec_in, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many Decs as RAs to " \
                          + "ampqkVector")
 
@@ -238,7 +238,7 @@ class TestPAL(unittest.TestCase) :
 
         with self.assertRaises(ValueError) as context:
             results = pal.aopqkVector(raIn[:6], decIn, obsrms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of Decs as RAs " \
                          + "to aopqkVector")
 
@@ -415,7 +415,7 @@ class TestPAL(unittest.TestCase) :
         # have the same length
         with self.assertRaises(ValueError) as context:
             testRa, testDec = pal.oapqkVector('a', azList, zdList[:17], aoprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The observed coordinate arrays you passed into " \
                          + "oapqkVector are of different lengths")
 
@@ -460,19 +460,19 @@ class TestPAL(unittest.TestCase) :
         # incorrect size
         with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in[:9], a2_in, b2_in)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The first two arguments of dbearVector must " \
                          + "be numpy arrays with the same number of elements")
 
         with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in, a2_in, b2_in[:8])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The second two arguments of dbearVector must " \
                          + "be numpy arrays with the same number of elements")
 
         with self.assertRaises(ValueError) as context:
             bTest = pal.dbearVector(a1_in, b1_in, a2_in[:9], b2_in[:9])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The second two arguments of dbearVector must " \
                          + "either have the same number of elements " \
                          + "as the first two arguments, or they must have " \
@@ -513,7 +513,7 @@ class TestPAL(unittest.TestCase) :
         # test that exceptions are raised when they should be
         with self.assertRaises(ValueError) as context:
             testPa = pal.dpavVector(v1, v2[:19])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dpavVector, v2 must either be a numpy array of " \
                          + "shape (3,) or a numpy array of shape (n, 3) "\
                          + "where n is the number of rows in v1")
@@ -521,21 +521,21 @@ class TestPAL(unittest.TestCase) :
         v3 = np.random.random_sample((nSamples, 6))
         with self.assertRaises(ValueError) as context:
             testPa = pal.dpavVector(v3, v2)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dpavVector, v1 must be a numpy array in which " \
                          + "each row has 3 elements. " \
                          + "Your rows have 6 elements.")
 
         with self.assertRaises(ValueError) as context:
             testPa = pal.dpavVector(v1, v3)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dpavVector, v2 must be a numpy array in which " \
                          + "each row has 3 elements. " \
                          + "Your rows have 6 elements.")
 
         with self.assertRaises(ValueError) as context:
             testPa = pal.dpavVector(v1, np.random.random_sample(9))
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The v2 you passed into dpavVector represents a single " \
                          "point with 9 elements; it should have 3 elements")
 
@@ -589,13 +589,13 @@ class TestPAL(unittest.TestCase) :
         # of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.caldjVector(iy, im[:11], iday)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many months as " \
                          + "years to caldjVector")
 
         with self.assertRaises(ValueError) as context:
             results = pal.caldjVector(iy, im, iday[:8])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many days as " \
                          + "years to caldjVector")
 
@@ -654,7 +654,7 @@ class TestPAL(unittest.TestCase) :
         dummyData = np.random.random_sample((20, 5))*10.0
         with self.assertRaises(ValueError) as context:
             aTest, bTest = pal.dcc2sVector(dummyData)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The input to dcc2sVector should be " \
                          + "a 2-D numpy array in which each row " \
                          + "is a point in 3-D Cartesian coordinates." \
@@ -684,7 +684,7 @@ class TestPAL(unittest.TestCase) :
         # test that an exception is raised if you pass in arrays of different lengths
         with self.assertRaises(ValueError) as context:
             vTest = pal.dcs2cVector(ra, dec[:16])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many latitudes as longitudes " \
                           + "into dcs2sVector")
 
@@ -827,13 +827,13 @@ class TestPAL(unittest.TestCase) :
         # mis-matched input arrays
         with self.assertRaises(ValueError) as context:
             testDays = pal.dtf2dVector(iHour, iMin[:19], sec)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dtf2dVector, imin does not have the " \
                          + "same length as ihour")
 
         with self.assertRaises(ValueError) as context:
             testDays = pal.dtf2dVector(iHour, iMin, sec[:19])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dtf2dVector, sec does not have the " \
                          + "same length as ihour")
 
@@ -879,13 +879,13 @@ class TestPAL(unittest.TestCase) :
         # mis-matched input arrays
         with self.assertRaises(ValueError) as context:
             testRad = pal.dtf2rVector(iHour, iMin[:19], sec)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dtf2rVector, imin does not have the " \
                          + "same length as ihour")
 
         with self.assertRaises(ValueError) as context:
             testRad = pal.dtf2rVector(iHour, iMin, sec[:19])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dtf2rVector, sec does not have the " \
                          + "same length as ihour")
 
@@ -1013,7 +1013,7 @@ class TestPAL(unittest.TestCase) :
         # of the same length
         with self.assertRaises(ValueError) as context:
             results = pal.de2hVector(haIn[:10], decIn, phi)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          + "Decs as Hour Angles to de2hVector")
 
@@ -1048,7 +1048,7 @@ class TestPAL(unittest.TestCase) :
         # are of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.dh2eVector(az[:40], el, phi)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many elevations " \
                          + "as azimuths to dh2eVector")
 
@@ -1088,7 +1088,7 @@ class TestPAL(unittest.TestCase) :
         # of different lenghts
         with self.assertRaises(ValueError) as context:
             results = pal.ecleqVector(dl[:4], db, mjd)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          + "longitudes as latitudes to ecleqVector")
 
@@ -1171,7 +1171,7 @@ class TestPAL(unittest.TestCase) :
         # different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.eqeclVector(ra, dec[:8], mjd)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of Decs " \
                          + "as RAs to eqeclVector")
 
@@ -1216,7 +1216,7 @@ class TestPAL(unittest.TestCase) :
         # arrays are of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.eqgalVector(raIn[:2], decIn)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of RAs " \
                          + "as Decs to eqgalVector")
 
@@ -1418,27 +1418,27 @@ class TestPAL(unittest.TestCase) :
         # of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.fk524Vector(ra5, dec5[:6], mura5, mudec5, px5, vr5)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many Decs as RAs into fk524Vector")
 
         with self.assertRaises(ValueError) as context:
             results = pal.fk524Vector(ra5, dec5, mura5[:8], mudec5, px5, vr5)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many RA proper motions as RAs into fk524Vector")
 
         with self.assertRaises(ValueError) as context:
             results = pal.fk524Vector(ra5, dec5, mura5, mudec5[:6], px5, vr5)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many Dec proper motions as RAs into fk524Vector")
 
         with self.assertRaises(ValueError) as context:
             results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5[:9], vr5)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many parallaxes as RAs into fk524Vector")
 
         with self.assertRaises(ValueError) as context:
             results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5, vr5[:9])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many radial velocities as RAs into fk524Vector")
 
 
@@ -1478,7 +1478,7 @@ class TestPAL(unittest.TestCase) :
         # lengths
         with self.assertRaises(ValueError) as context:
             results = pal.fk45zVector(r1950, d1950[:8], epoch)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of Decs as RAs to " \
                          + "fk45zVector")
 
@@ -1515,7 +1515,7 @@ class TestPAL(unittest.TestCase) :
         # are of different sizes
         with self.assertRaises(ValueError) as context:
             testRa, testDec = pal.fk5hzVector(raList, decList[:24], 2000.0)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          "RAs as Decs to fk5hzVector")
 
@@ -1546,7 +1546,7 @@ class TestPAL(unittest.TestCase) :
         # of different lengths
         with self.assertRaises(ValueError) as context:
             ra, dec, dr, dd = pal.hfk5zVector(raList, decList[:77], 2000.0)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of RAs as " \
                          + "Decs to hfk5zVector")
 
@@ -1583,7 +1583,7 @@ class TestPAL(unittest.TestCase) :
         # different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.fk54zVector(r2000[:11], d2000, epoch)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of Decs as " \
                          +"RAs to fk54zVector")
 
@@ -1614,7 +1614,7 @@ class TestPAL(unittest.TestCase) :
         # are of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.galeqVector(dlIn[:3], dbIn)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of longitudes " \
                          + "as latitudes to galeqVector")
 
@@ -1645,7 +1645,7 @@ class TestPAL(unittest.TestCase) :
         # different lengths
         with self.assertRaises(ValueError) as context:
             testSl, testSb = pal.galsupVector(llList[:55], bbList)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          + "Galactic longitudes as Galactic latitudes " \
                          + "into galsupVector")
@@ -1681,7 +1681,7 @@ class TestPAL(unittest.TestCase) :
         # numbers of longitudes as you do latitudes
         with self.assertRaises(ValueError) as context:
             testRa, testDec = pal.ge50Vector(llList, bbList[:45])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          + "Galactic longitudes as Galactic latitudes " \
                          + "into ge50Vector")
@@ -1718,7 +1718,7 @@ class TestPAL(unittest.TestCase) :
         # of different lengths
         with self.assertRaises(ValueError) as context:
             results = pal.gmstaVector(dateIn[:8], utIn)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into gmstaVector " \
                          + "are of different lengths")
 
@@ -1816,7 +1816,7 @@ class TestPAL(unittest.TestCase) :
         # are of inconsistent lengths
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkzVector(raIn[:4], decIn, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many RAs as Decs " \
                          + "to mapqkzVector")
 
@@ -1850,31 +1850,31 @@ class TestPAL(unittest.TestCase) :
         # are of inconsistent shapes
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkVector(raIn, decIn[:10], pmr, pmd, px, rv, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into mapqkVector are " \
                          + "not of the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkVector(raIn, decIn, pmr[:10], pmd, px, rv, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into mapqkVector are " \
                          + "not of the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkVector(raIn, decIn, pmr, pmd[:10], px, rv, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into mapqkVector are " \
                          + "not of the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkVector(raIn, decIn, pmr, pmd, px[:10], rv, amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into mapqkVector are " \
                          + "not of the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.mapqkVector(raIn, decIn, pmr, pmd, px, rv[:10], amprms)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into mapqkVector are " \
                          + "not of the same length")
 
@@ -1957,7 +1957,7 @@ class TestPAL(unittest.TestCase) :
         # are of inconsistent length
         with self.assertRaises(ValueError) as context:
             results = pal.paVector(haIn[:4], decIn, phi)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many Decs as " \
                          + "Hour Angles to paVector")
 
@@ -2008,7 +2008,7 @@ class TestPAL(unittest.TestCase) :
         # mismatched x and y vectors
         with self.assertRaises(ValueError) as context:
             xTestList, yTestLIst = pal.pcdVector(disco, x_in, y_in[:10])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of x as y " \
                          + "coordinates to pcdVector")
 
@@ -2047,7 +2047,7 @@ class TestPAL(unittest.TestCase) :
         # of x and y coordinates
         with self.assertRaises(ValueError) as context:
             xTestList, yTestList = pal.unpcdVector(disco, x_in, y_in[:30])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of x as y " \
                          + "coordinates to unpcdVector")
 
@@ -2270,31 +2270,31 @@ class TestPAL(unittest.TestCase) :
         # inconsistent length
         with self.assertRaises(ValueError) as context:
             results = pal.pmVector(raIn, decIn[:3], pmr, pmd, px, rv, ep0, ep1)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into pmVector are not all of " \
                          + "the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.pmVector(raIn, decIn, pmr[:3], pmd, px, rv, ep0, ep1)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into pmVector are not all of " \
                          + "the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.pmVector(raIn, decIn, pmr, pmd[:3], px, rv, ep0, ep1)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into pmVector are not all of " \
                          + "the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.pmVector(raIn, decIn, pmr, pmd, px[:3], rv, ep0, ep1)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into pmVector are not all of " \
                          + "the same length")
 
         with self.assertRaises(ValueError) as context:
             results = pal.pmVector(raIn, decIn, pmr, pmd, px, rv[:3], ep0, ep1)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays you passed into pmVector are not all of " \
                          + "the same length")
 
@@ -2545,19 +2545,19 @@ class TestPAL(unittest.TestCase) :
         # have different lengths
         with self.assertRaises(ValueError) as context:
             resutls = pal.dsepVector(ra1, dec1[:5], ra2, dec2)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                         "The arrays you passed to dsepVector " \
                          + "are not of the same length")
 
         with self.assertRaises(ValueError) as context:
             resutls = pal.dsepVector(ra1, dec1, ra2[:5], dec2)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                         "The arrays you passed to dsepVector " \
                          + "are not of the same length")
 
         with self.assertRaises(ValueError) as context:
             resutls = pal.dsepVector(ra1, dec1, ra2, dec2[:5])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                         "The arrays you passed to dsepVector " \
                          + "are not of the same length")
 
@@ -2586,28 +2586,28 @@ class TestPAL(unittest.TestCase) :
         # test that exceptions are raised when they ought to be
         with self.assertRaises(ValueError) as context:
             testSep = pal.dsepvVector(v1, v2[0:19])
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dsepvVector v2 must either have one row or " \
                          + "n rows, where n is the number of rows in v1")
 
         v3 = np.random.random_sample((nSamples,2))
         with self.assertRaises(ValueError) as context:
             testSep = pal.dsepvVector(v3, v2)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dsepvVector v1 must be a numpy array " \
                          + "in which each row corresponds to a direction " \
                          + "in 3-D space.  Your v1 has 2 columns.")
 
         with self.assertRaises(ValueError) as context:
             testSep = pal.dsepvVector(v1, v3)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "In dsepvVector v2 must be a numpy array " \
                          + "in which each row corresponds to a direction " \
                          + "in 3-D space.  Your v2 has 2 columns.")
 
         with self.assertRaises(ValueError) as context:
             testSep = pal.dsepvVector(v1, np.random.random_sample(4))
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                           "The v2 you passed to dsepvVector is a single point " \
                           + "with 4 elements; it should have 3 elements")
 
@@ -2643,7 +2643,7 @@ class TestPAL(unittest.TestCase) :
         # different length
         with self.assertRaises(ValueError) as context:
             testDl, testDb = pal.supgalVector(dslList[:16], dsbList)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass the same number of " \
                          + "longitudes as latitudes into supgalVector")
 
@@ -2706,7 +2706,7 @@ class TestPAL(unittest.TestCase) :
         # are not of the same shape
         with self.assertRaises(ValueError) as context:
             results = pal.ds2tpVector(raIn[:3], decIn, raz, decz)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "You did not pass as many RAs as Decs " \
                          + "to ds2tpVector")
 
@@ -2742,7 +2742,7 @@ class TestPAL(unittest.TestCase) :
         # different sizes
         with self.assertRaises(ValueError) as context:
             results = pal.dtp2sVector(xi, eta[:20], raz, decz)
-        self.assertEqual(context.exception.message,
+        self.assertEqual(context.exception.args[0],
                          "The arrays of tangent plane coordinates " \
                          + "you passed to dtp2sVector are of " \
                          + "different lengths")

--- a/test_pal.py
+++ b/test_pal.py
@@ -802,6 +802,20 @@ class TestPAL(unittest.TestCase) :
     def test_epj(self):
         self.assertAlmostEqual( pal.epj(42999), 1976.603696098563, 7)
 
+    def test_epjVector(self):
+        """
+        Test that epjVector returns results consistent with epj
+        """
+        np.random.seed(45738)
+        nSamples = 300
+        date = 43000.0 + np.random.random_sample(nSamples)*10000.0
+        testEpj = pal.epjVector(date)
+        for ii in range(nSamples):
+            controlEpj = pal.epj(date[ii])
+            self.assertEqual(controlEpj, testEpj[ii])
+            self.assertFalse(np.isnan(testEpj[ii]))
+
+
     def test_epj2d(self):
         self.assertAlmostEqual( pal.epj2d(2010.077), 55225.124250, 6 )
 

--- a/test_pal.py
+++ b/test_pal.py
@@ -797,6 +797,52 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( d, 10 )
         self.assertAlmostEqual( f, 0.9999, 7 )
 
+    def test_djcalVector(self):
+        """
+        Test that djcalVector returns results consistent with djcal
+        """
+        np.random.seed(142)
+        nSamples = 200
+        mjd = (np.random.random_sample(nSamples)-0.5)*100000.0
+
+        for ndp in [2,3,4,5]:
+
+            testY, testM, \
+            testD, testFrac = pal.djcalVector(ndp, mjd)
+
+            for ii in range(nSamples):
+                controlY, controlM, \
+                controlD, controlFrac = pal.djcal(ndp, mjd[ii])
+
+                self.assertEqual(controlY, testY[ii])
+                self.assertEqual(controlM, testM[ii])
+                self.assertEqual(controlD, testD[ii])
+                self.assertEqual(controlFrac, testFrac[ii])
+
+
+        ndp = 4
+        # test that unacceptable dates result in -1 being placed in all
+        # of the output slots
+        mjd[4] = -2468570
+        mjd[5] = -2468571
+        mjd[9] = 1.0e8
+        mjd[10] = 1.0e9
+        testY, testM, testD, testFrac = pal.djcalVector(ndp, mjd)
+        for ii in range(nSamples):
+            if ii==5 or ii==10:
+                self.assertEqual(testY[ii], -1)
+                self.assertEqual(testM[ii], -1)
+                self.assertEqual(testD[ii], -1)
+                self.assertEqual(testFrac[ii], -1)
+                self.assertRaises(ValueError, pal.djcal, ndp, mjd[ii])
+            else:
+                controlY, controlM, \
+                controlD, controlFrac = pal.djcal(ndp, mjd[ii])
+                self.assertEqual(controlY, testY[ii])
+                self.assertEqual(controlM, testM[ii])
+                self.assertEqual(controlD, testD[ii])
+                self.assertEqual(controlFrac, testFrac[ii])
+
     def test_dmat(self):
         da = np.array(
            [ [ 2.22,     1.6578,     1.380522 ],

--- a/test_pal.py
+++ b/test_pal.py
@@ -1101,6 +1101,33 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dsl, 4.567933268859171, 12 )
         self.assertAlmostEqual( dsb, -0.01862369899731829, 12 )
 
+    def test_galsupVector(self):
+        """
+        Test that galsupVector gives results consistent with galsup
+        """
+        np.random.seed(134)
+        nSamples = 200
+
+        llList = np.random.random_sample(nSamples)*2.0*np.pi
+        bbList = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        testSl, testSb = pal.galsupVector(llList, bbList)
+
+        for ii in range(nSamples):
+            controlSl, controlSb = pal.galsup(llList[ii], bbList[ii])
+            self.assertEqual(controlSl, testSl[ii])
+            self.assertEqual(controlSb, testSb[ii])
+
+        # test that an exception is raised if you pass in arrays with
+        # different lengths
+        with self.assertRaises(ValueError) as context:
+            testSl, testSb = pal.galsupVector(llList[:55], bbList)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         + "Galactic longitudes as Galactic latitudes " \
+                         + "into galsupVector")
+
+
     def test_geoc(self):
         lat = 19.822838905884 * pal.DD2R
         alt = 4120.0

--- a/test_pal.py
+++ b/test_pal.py
@@ -1250,6 +1250,35 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dr1950, -1.7830874775952945507e-08, 12 )
         self.assertAlmostEqual( dd1950, 7.196059425334821089e-09, 12 )
 
+    def test_fk54zVector(self):
+        """
+        Test that fk54zVector returns results consistent with fk54z
+        """
+        epoch = 1960
+        np.random.seed(136)
+        nSamples = 200
+        r2000 = np.random.random_sample(nSamples)*2.0*np.pi
+        d2000 = (np.random.random_sample(nSamples)-0.5)*np.pi
+        testR1950, testD1950, \
+        testDr1950, testDd1950 = pal.fk54zVector(r2000, d2000, epoch)
+
+        for ii in range(nSamples):
+            controlR1950, controlD1950, \
+            controlDr1950, controlDd1950 = pal.fk54z(r2000[ii], d2000[ii], epoch)
+
+            self.assertEqual(controlR1950, testR1950[ii])
+            self.assertEqual(controlD1950, testD1950[ii])
+            self.assertEqual(controlDr1950, testDr1950[ii])
+            self.assertEqual(controlDd1950, testDd1950[ii])
+
+        # test that an exception is raised if input arrays are of
+        # different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk54zVector(r2000[:11], d2000, epoch)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of Decs as " \
+                         +"RAs to fk54zVector")
+
     def test_flotin(self):
         pass
 

--- a/test_pal.py
+++ b/test_pal.py
@@ -1610,6 +1610,15 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(drt, drc, 12)
             self.assertAlmostEqual(ddt, ddc, 12)
 
+        # test that an exception is raise if input arrays
+        # are of different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.galeqVector(dlIn[:3], dbIn)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of longitudes " \
+                         + "as latitudes to galeqVector")
+
+
     def test_galsup(self):
         (dsl, dsb) = pal.galsup( 6.1, -1.4 )
         self.assertAlmostEqual( dsl, 4.567933268859171, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -876,12 +876,12 @@ class TestPAL(unittest.TestCase) :
         nTests = 100
         phi = 0.35
         np.random.seed(32)
-        raIn = np.random.random_sample(nTests)*np.pi*2.0
+        haIn = np.random.random_sample(nTests)*np.pi*2.0
         decIn = (np.random.random_sample(nTests)-0.5)*np.pi
         azControl = None
         elControl = None
-        for (rr,dd) in zip (raIn,decIn):
-            az, el = pal.de2h(rr, dd, phi)
+        for (ha,dd) in zip (haIn,decIn):
+            az, el = pal.de2h(ha, dd, phi)
             if azControl is None:
                 azControl = np.array([az])
                 elControl = np.array([el])
@@ -889,7 +889,7 @@ class TestPAL(unittest.TestCase) :
                 azControl = np.append(azControl,az)
                 elControl = np.append(elControl,el)
 
-        azTest, elTest = pal.de2hVector(raIn, decIn, phi)
+        azTest, elTest = pal.de2hVector(haIn, decIn, phi)
         for (a1,e1,a2,e2) in zip (azControl,elControl,azTest,elTest):
             self.assertAlmostEqual(a1,a2,12)
             self.assertAlmostEqual(e1,e2,12)

--- a/test_pal.py
+++ b/test_pal.py
@@ -1113,6 +1113,30 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dr, 0.1966825219934508, 12 )
         self.assertAlmostEqual( dd, -0.4924752701678960, 12 )
 
+    def test_ge50Vector(self):
+        """
+        Test that ge50Vector returns results consistent with ge50
+        """
+        np.random.seed(133)
+        nSamples = 200
+        llList = np.random.random_sample(nSamples)*2.0*np.pi
+        bbList = (np.random.random_sample(nSamples)-0.5)*np.pi
+        testRa, testDec = pal.ge50Vector(llList, bbList)
+        for ii in range(nSamples):
+            controlRa, controlDec = pal.ge50(llList[ii], bbList[ii])
+            self.assertEqual(controlRa, testRa[ii])
+            self.assertEqual(controlDec, testDec[ii])
+
+        # test that an exception is raised when you pass in different
+        # numbers of longitudes as you do latitudes
+        with self.assertRaises(ValueError) as context:
+            testRa, testDec = pal.ge50Vector(llList, bbList[:45])
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         + "Galactic longitudes as Galactic latitudes " \
+                         + "into ge50Vector")
+
+
     def test_gmst(self):
         self.assertAlmostEqual( pal.gmst( 53736 ), 1.754174971870091203, 12 )
         self.assertAlmostEqual( pal.gmsta( 53736, 0 ), 1.754174971870091203, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -1212,6 +1212,15 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(dlt, dlc, 12)
             self.assertAlmostEqual(dbt, dbc, 12)
 
+        # test that an exception is raised when the input
+        # arrays are of different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.eqgalVector(raIn[:2], decIn)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of RAs " \
+                         + "as Decs to eqgalVector")
+
+
     def test_etrms(self):
         ev = pal.etrms( 1976.9 )
         self.assertAlmostEqual( ev[0], -1.621617102537041e-6, 18 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -487,10 +487,10 @@ class TestPAL(unittest.TestCase) :
 
         # test that dcs2cVector and dcc2sVector do, in fact, invert one another
         aTest, bTest = pal.dcc2sVector(vTest)
-        np.testing.assert_array_almost_equal(np.cos(ra), np.cos(aTest), 9)
-        np.testing.assert_array_almost_equal(np.sin(ra), np.sin(aTest), 9)
-        np.testing.assert_array_almost_equal(np.cos(dec), np.cos(bTest), 9)
-        np.testing.assert_array_almost_equal(np.sin(dec), np.sin(bTest), 9)
+        np.testing.assert_array_almost_equal(np.cos(ra), np.cos(aTest), 12)
+        np.testing.assert_array_almost_equal(np.sin(ra), np.sin(aTest), 12)
+        np.testing.assert_array_almost_equal(np.cos(dec), np.cos(bTest), 12)
+        np.testing.assert_array_almost_equal(np.sin(dec), np.sin(bTest), 12)
 
         # test that an exception is raised if you pass in arrays of different lengths
         with self.assertRaises(ValueError) as context:
@@ -980,8 +980,8 @@ class TestPAL(unittest.TestCase) :
 
         # test hfk5zVector anf fk5hzVector invert each other
         ra5, dec5 = pal.fk5hzVector(testRa, testDec, 2000.0)
-        np.testing.assert_array_almost_equal(ra5, raList, 11)
-        np.testing.assert_array_almost_equal(dec5, decList, 11)
+        np.testing.assert_array_almost_equal(ra5, raList, 12)
+        np.testing.assert_array_almost_equal(dec5, decList, 12)
 
         # test that an exception is raised if raList and decList are
         # of different lengths
@@ -1276,10 +1276,10 @@ class TestPAL(unittest.TestCase) :
         # (also make sure that x_in and y_in were not changed
         # by pcdVector)
         with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(xTestList, x_in, 9)
+            np.testing.assert_array_almost_equal(xTestList, x_in, 12)
 
         with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(yTestList, y_in, 9)
+            np.testing.assert_array_almost_equal(yTestList, y_in, 12)
 
         # make sure that an exceptoion is raised if you pass in
         # mismatched x and y vectors
@@ -1309,16 +1309,16 @@ class TestPAL(unittest.TestCase) :
 
         # make sure that xTestList and yTestList are different from x_in and y_in
         with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(xTestList, x_in, 9)
+            np.testing.assert_array_almost_equal(xTestList, x_in, 12)
 
         with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(yTestList, y_in ,9)
+            np.testing.assert_array_almost_equal(yTestList, y_in, 12)
 
         # use pcdVector to transform back into the distorted coordinates and
         # verify that those are equivalent to x_in and y_in
         xDistorted, yDistorted = pal.pcdVector(disco, xTestList, yTestList)
-        np.testing.assert_array_almost_equal(xDistorted, x_in, 9)
-        np.testing.assert_array_almost_equal(yDistorted, y_in, 9)
+        np.testing.assert_array_almost_equal(xDistorted, x_in, 12)
+        np.testing.assert_array_almost_equal(yDistorted, y_in, 12)
 
         # test that an exception is raised if you pass in different numbers
         # of x and y coordinates
@@ -1613,8 +1613,8 @@ class TestPAL(unittest.TestCase) :
         # angles normalized to the 0-2pi ranges
         self.assertTrue(testAngle.min()>0.0)
         self.assertTrue(testAngle.max()<2.0*np.pi)
-        np.testing.assert_array_almost_equal(np.cos(testAngle), np.cos(angle_in), 9)
-        np.testing.assert_array_almost_equal(np.sin(testAngle), np.sin(angle_in), 9)
+        np.testing.assert_array_almost_equal(np.cos(testAngle), np.cos(angle_in), 12)
+        np.testing.assert_array_almost_equal(np.sin(testAngle), np.sin(angle_in), 12)
 
         for ii in range(nSamples):
             controlAngle = pal.dranrm(angle_in[ii])

--- a/test_pal.py
+++ b/test_pal.py
@@ -1590,6 +1590,58 @@ class TestPAL(unittest.TestCase) :
         for (ddc, ddt) in zip (ddTest, ddControl):
             self.assertAlmostEqual(ddc, ddt, 12)
 
+
+    def test_dsepvVector(self):
+        """
+        Test that dsepvVector produces results that agree
+        with dsepv
+        """
+        np.random.seed(130)
+        nSamples = 100
+        v1 = (np.random.random_sample((nSamples, 3))-0.5)*100.0
+        v2 = (np.random.random_sample((nSamples, 3))-0.5)*100.0
+
+        testSep = pal.dsepvVector(v1, v2)
+        for ii in range(nSamples):
+            controlSep = pal.dsepv(v1[ii], v2[ii])
+            self.assertEqual(controlSep, testSep[ii])
+            self.assertFalse(np.isnan(testSep[ii]))
+
+        testSep = pal.dsepvVector(v1, v2[6])
+        for ii in range(nSamples):
+            controlSep = pal.dsepv(v1[ii], v2[6])
+            self.assertEqual(controlSep, testSep[ii])
+            self.assertFalse(np.isnan(testSep[ii]))
+
+        # test that exceptions are raised when they ought to be
+        with self.assertRaises(ValueError) as context:
+            testSep = pal.dsepvVector(v1, v2[0:19])
+        self.assertEqual(context.exception.message,
+                         "In dsepvVector v2 must either have one row or " \
+                         + "n rows, where n is the number of rows in v1")
+
+        v3 = np.random.random_sample((nSamples,2))
+        with self.assertRaises(ValueError) as context:
+            testSep = pal.dsepvVector(v3, v2)
+        self.assertEqual(context.exception.message,
+                         "In dsepvVector v1 must be a numpy array " \
+                         + "in which each row corresponds to a direction " \
+                         + "in 3-D space.  Your v1 has 2 columns.")
+
+        with self.assertRaises(ValueError) as context:
+            testSep = pal.dsepvVector(v1, v3)
+        self.assertEqual(context.exception.message,
+                         "In dsepvVector v2 must be a numpy array " \
+                         + "in which each row corresponds to a direction " \
+                         + "in 3-D space.  Your v2 has 2 columns.")
+
+        with self.assertRaises(ValueError) as context:
+            testSep = pal.dsepvVector(v1, np.random.random_sample(4))
+        self.assertEqual(context.exception.message,
+                          "The v2 you passed to dsepvVector is a single point " \
+                          + "with 4 elements; it should have 3 elements")
+
+
     def test_supgal(self):
         (dl, db) = pal.supgal( 6.1, -1.4 )
         self.assertAlmostEqual( dl, 3.798775860769474, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -538,6 +538,29 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( sec, 30 )
         self.assertEqual( f, 9706 )
 
+    def test_dr2afVector(self):
+        """
+        Test that dr2afVector produces the same results as
+        dr2af
+        """
+        np.random.seed(128)
+        nSamples = 200
+        angleList = (np.random.random_sample(nSamples)-0.5)*4.0*np.pi
+        for npd in [2, 3, 4, 5]:
+            testSign, testDeg, \
+            testMin, testSec, testFrac = pal.dr2afVector(npd, angleList)
+
+            for ii in range(nSamples):
+                controlSign, controlDeg, \
+                controlMin, controlSec, controlFrac = pal.dr2af(npd, angleList[ii])
+
+                self.assertEqual(controlSign, testSign[ii])
+                self.assertEqual(controlDeg, testDeg[ii])
+                self.assertEqual(controlMin, testMin[ii])
+                self.assertEqual(controlSec, testSec[ii])
+                self.assertEqual(controlFrac, testFrac[ii])
+
+
     def test_dr2tf(self):
         (sign, hr, min, sec, f) = pal.dr2tf( 4, -3.01234 )
         self.assertEqual( sign, "-" )

--- a/test_pal.py
+++ b/test_pal.py
@@ -2323,6 +2323,42 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(x1,x2,12)
             self.assertAlmostEqual(e1,e2,12)
 
+    def test_dtp2sVector(self):
+        """
+        Test that dtp2sVector produces results consistent with
+        dtp2s
+        """
+
+        np.random.seed(139)
+        nSamples = 200
+        raz = 0.9
+        decz = -0.3
+
+        xi = np.random.random_sample(nSamples)*5.0
+        eta = np.random.random_sample(nSamples)*5.0
+        testRa, testDec = pal.dtp2sVector(xi, eta, raz, decz)
+
+        for ii in range(nSamples):
+            controlRa, controlDec = pal.dtp2s(xi[ii], eta[ii], raz, decz)
+            self.assertEqual(testRa[ii], controlRa)
+            self.assertEqual(testDec[ii], controlDec)
+            self.assertFalse(np.isnan(testRa[ii]))
+            self.assertFalse(np.isnan(testDec[ii]))
+
+        # test that dtp2sVector and ds2tpVector invert each other
+        testXi, testEta = pal.ds2tpVector(testRa, testDec, raz, decz)
+        np.testing.assert_array_almost_equal(testXi, xi, 12)
+        np.testing.assert_array_almost_equal(testEta, eta, 12)
+
+        # test that an exception is raised if input arrays are of
+        # different sizes
+        with self.assertRaises(ValueError) as context:
+            results = pal.dtp2sVector(xi, eta[:20], raz, decz)
+        self.assertEqual(context.exception.message,
+                         "The arrays of tangent plane coordinates " \
+                         + "you passed to dtp2sVector are of " \
+                         + "different lengths")
+
     def test_vecmat(self):
         # Not everything is implemented here
         dav = np.array( [ -0.123, 0.0987, 0.0654 ] )

--- a/test_pal.py
+++ b/test_pal.py
@@ -530,7 +530,7 @@ class TestPAL(unittest.TestCase) :
         self.assertRaises( ValueError, pal.cldj, 1970, 13, 1 )
         self.assertRaises( ValueError, pal.cldj, 1970, 1, 32 )
 
-    def test_cr2af(self):
+    def test_dr2af(self):
         (sign, deg, min, sec, f) = pal.dr2af( 4, 2.345 )
         self.assertEqual( sign, "+" )
         self.assertEqual( deg, 134 )
@@ -538,7 +538,7 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( sec, 30 )
         self.assertEqual( f, 9706 )
 
-    def test_cr2tf(self):
+    def test_dr2tf(self):
         (sign, hr, min, sec, f) = pal.dr2tf( 4, -3.01234 )
         self.assertEqual( sign, "-" )
         self.assertEqual( hr, 11 )
@@ -546,14 +546,14 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( sec, 22 )
         self.assertEqual( f, 6484 )
 
-    def test_ctf2d(self):
+    def test_dtf2d(self):
         dd = pal.dtf2d( 23, 56, 59.1 )
         self.assertAlmostEqual( dd, 0.99790625, 12 )
         self.assertRaises( ValueError, pal.dtf2d, 24, 1, 32 )
         self.assertRaises( ValueError, pal.dtf2d, 23, -1, 32 )
         self.assertRaises( ValueError, pal.dtf2d, 23, 1, 60 )
 
-    def test_ctf2r(self):
+    def test_dtf2r(self):
         dr = pal.dtf2r( 23, 56, 59.1 )
         self.assertAlmostEqual( dr, 6.270029887942679, 12 )
         self.assertRaises( ValueError, pal.dtf2r, 24, 1, 32 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -853,6 +853,41 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dr, 1.229910118208851, 5 )
         self.assertAlmostEqual( dd, 0.2638461400411088, 5 )
 
+    def test_ecleqVector(self):
+        """
+        Test that ecleqVector produces results consistent with
+        ecleq
+        """
+        mjd = 58734.2
+        np.random.seed(138)
+        nSamples = 200
+        dl = np.random.random_sample(nSamples)*2.0*np.pi
+        db = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        testRa, testDec = pal.ecleqVector(dl, db, mjd)
+
+        for ii in range(nSamples):
+            controlRa, controlDec = pal.ecleq(dl[ii], db[ii], mjd)
+            self.assertEqual(controlRa, testRa[ii])
+            self.assertEqual(controlDec, testDec[ii])
+
+        # test that ecleqVector and eqeclVector invert
+        # one another
+        testDl, testDb = pal.eqeclVector(testRa, testDec, mjd)
+        arcsecPerRadian = 3600.0*np.degrees(1.0)
+        distance = arcsecPerRadian*pal.dsepVector(testDl, testDb, dl, db)
+        np.testing.assert_array_almost_equal(distance,
+                                             np.zeros(len(distance)), 4)
+
+        # test that an exception is raised if input arrays are
+        # of different lenghts
+        with self.assertRaises(ValueError) as context:
+            results = pal.ecleqVector(dl[:4], db, mjd)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         + "longitudes as latitudes to ecleqVector")
+
+
     def test_ecmat(self):
         expected = np.array( [
             [ 1.0,                    0.0,                   0.0 ],

--- a/test_pal.py
+++ b/test_pal.py
@@ -1009,6 +1009,14 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(a1,a2,12)
             self.assertAlmostEqual(e1,e2,12)
 
+        # test that an exception is raised if inputs are not
+        # of the same length
+        with self.assertRaises(ValueError) as context:
+            results = pal.de2hVector(haIn[:10], decIn, phi)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         + "Decs as Hour Angles to de2hVector")
+
 
     def test_dh2eVector(self):
         """

--- a/test_pal.py
+++ b/test_pal.py
@@ -2435,6 +2435,25 @@ class TestPAL(unittest.TestCase) :
         for (ddc, ddt) in zip (ddTest, ddControl):
             self.assertAlmostEqual(ddc, ddt, 12)
 
+        # test that an exception is raised if input arrays
+        # have different lengths
+        with self.assertRaises(ValueError) as context:
+            resutls = pal.dsepVector(ra1, dec1[:5], ra2, dec2)
+        self.assertEqual(context.exception.message,
+                        "The arrays you passed to dsepVector " \
+                         + "are not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            resutls = pal.dsepVector(ra1, dec1, ra2[:5], dec2)
+        self.assertEqual(context.exception.message,
+                        "The arrays you passed to dsepVector " \
+                         + "are not of the same length")
+
+        with self.assertRaises(ValueError) as context:
+            resutls = pal.dsepVector(ra1, dec1, ra2, dec2[:5])
+        self.assertEqual(context.exception.message,
+                        "The arrays you passed to dsepVector " \
+                         + "are not of the same length")
 
     def test_dsepvVector(self):
         """

--- a/test_pal.py
+++ b/test_pal.py
@@ -1714,6 +1714,14 @@ class TestPAL(unittest.TestCase) :
         for gt, gc in zip(gmTest, gmControl):
             self.assertAlmostEqual(gt, gc, 12)
 
+        # test that an exception is raised if input arrays are
+        # of different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.gmstaVector(dateIn[:8], utIn)
+        self.assertEqual(context.exception.message,
+                         "The arrays you passed into gmstaVector " \
+                         + "are of different lengths")
+
     def test_intin(self):
         s = "  -12345, , -0  2000  +     "
         i = 1

--- a/test_pal.py
+++ b/test_pal.py
@@ -1812,6 +1812,14 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(r1,r2,12)
             self.assertAlmostEqual(d1,d2,12)
 
+        # test that an exception is raised if the input arrays
+        # are of inconsistent lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.mapqkzVector(raIn[:4], decIn, amprms)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many RAs as Decs " \
+                         + "to mapqkzVector")
+
     def test_mapqkVector(self):
         amprms = pal.mappa(2010, 55927)
         np.random.seed(32)

--- a/test_pal.py
+++ b/test_pal.py
@@ -2334,8 +2334,8 @@ class TestPAL(unittest.TestCase) :
         raz = 0.9
         decz = -0.3
 
-        xi = np.random.random_sample(nSamples)*5.0
-        eta = np.random.random_sample(nSamples)*5.0
+        xi = (np.random.random_sample(nSamples)-0.5)*10.0
+        eta = (np.random.random_sample(nSamples)-0.5)*10.0
         testRa, testDec = pal.dtp2sVector(xi, eta, raz, decz)
 
         for ii in range(nSamples):

--- a/test_pal.py
+++ b/test_pal.py
@@ -2564,6 +2564,28 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(x1,x2,12)
             self.assertAlmostEqual(e1,e2,12)
 
+        # test that bad input values get mapped to NaNs
+        raIn[5] = raz + np.pi
+        decIn[7] = decz + np.pi
+        xiTest, etaTest = pal.ds2tpVector(raIn, decIn, raz, decz)
+        for ii in range(len(raIn)):
+            if ii==5 or ii==7:
+                self.assertTrue(np.isnan(xiTest[ii]))
+                self.assertTrue(np.isnan(etaTest[ii]))
+                self.assertRaises(ValueError, pal.ds2tp, raIn[ii], decIn[ii], raz, decz)
+            else:
+                self.assertEqual(xiTest[ii], xiControl[ii])
+                self.assertEqual(etaTest[ii], etaControl[ii])
+
+        # test that an exception is raised if input arrays
+        # are not of the same shape
+        with self.assertRaises(ValueError) as context:
+            results = pal.ds2tpVector(raIn[:3], decIn, raz, decz)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many RAs as Decs " \
+                         + "to ds2tpVector")
+
+
     def test_dtp2sVector(self):
         """
         Test that dtp2sVector produces results consistent with

--- a/test_pal.py
+++ b/test_pal.py
@@ -131,11 +131,9 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(padC[i], padT[i], 12)
             self.assertAlmostEqual(paddC[i], paddT[i], 12)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.altazVector(haIn[:10], decIn, phi)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many Decs as Hour Angles " \
-                         + "to altazVector")
+        # test that an exception is raised if input arrays have
+        # different lengths
+        self.assertRaises(ValueError, pal.altazVector, haIn[:10], decIn, phi)
 
 
     def test_amp(self):
@@ -180,12 +178,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raised when input arrays are not of the same
         # length
-        with self.assertRaises(ValueError) as context:
-            results = pal.ampqkVector(ra_in[:17], dec_in, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many Decs as RAs to " \
-                         + "ampqkVector")
-
+        self.assertRaises(ValueError, pal.ampqkVector,ra_in[:17], dec_in, amprms)
 
     def test_aopqkVector(self):
         date = 51000.1
@@ -236,12 +229,9 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(d1,d2,12)
             self.assertAlmostEqual(r1,r2,12)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.aopqkVector(raIn[:6], decIn, obsrms)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of Decs as RAs " \
-                         + "to aopqkVector")
-
+        # test that an exception is raised if input arrays have
+        # different lengths
+        self.assertRaises(ValueError, pal.aopqkVector, raIn[:6], decIn, obsrms)
 
     def test_aop(self):
         dap = -0.1234
@@ -413,12 +403,8 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is thrown if the input arrays do not
         # have the same length
-        with self.assertRaises(ValueError) as context:
-            testRa, testDec = pal.oapqkVector('a', azList, zdList[:17], aoprms)
-        self.assertEqual(context.exception.args[0],
-                         "The observed coordinate arrays you passed into " \
-                         + "oapqkVector are of different lengths")
-
+        self.assertRaises(ValueError, pal.oapqkVector, 'a', \
+                          azList, zdList[:17], aoprms)
 
     def test_bear(self):
         a1 = 1.234
@@ -458,26 +444,11 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raied when the numpy arrays are of
         # incorrect size
-        with self.assertRaises(ValueError) as context:
-            bTest = pal.dbearVector(a1_in, b1_in[:9], a2_in, b2_in)
-        self.assertEqual(context.exception.args[0],
-                         "The first two arguments of dbearVector must " \
-                         + "be numpy arrays with the same number of elements")
+        self.assertRaises(ValueError, pal.dbearVector, a1_in, b1_in[:9], a2_in, b2_in)
 
-        with self.assertRaises(ValueError) as context:
-            bTest = pal.dbearVector(a1_in, b1_in, a2_in, b2_in[:8])
-        self.assertEqual(context.exception.args[0],
-                         "The second two arguments of dbearVector must " \
-                         + "be numpy arrays with the same number of elements")
+        self.assertRaises(ValueError, pal.dbearVector, a1_in, b1_in, a2_in, b2_in[:8])
 
-        with self.assertRaises(ValueError) as context:
-            bTest = pal.dbearVector(a1_in, b1_in, a2_in[:9], b2_in[:9])
-        self.assertEqual(context.exception.args[0],
-                         "The second two arguments of dbearVector must " \
-                         + "either have the same number of elements " \
-                         + "as the first two arguments, or they must have " \
-                         + "only one element")
-
+        self.assertRaises(ValueError, pal.dbearVector, a1_in, b1_in, a2_in[:9], b2_in[:9])
 
     def test_dpavVector(self):
         """
@@ -511,33 +482,15 @@ class TestPAL(unittest.TestCase) :
             self.assertFalse(np.isnan(paControl))
 
         # test that exceptions are raised when they should be
-        with self.assertRaises(ValueError) as context:
-            testPa = pal.dpavVector(v1, v2[:19])
-        self.assertEqual(context.exception.args[0],
-                         "In dpavVector, v2 must either be a numpy array of " \
-                         + "shape (3,) or a numpy array of shape (n, 3) "\
-                         + "where n is the number of rows in v1")
+        self.assertRaises(ValueError, pal.dpavVector, v1, v2[:19])
 
         v3 = np.random.random_sample((nSamples, 6))
-        with self.assertRaises(ValueError) as context:
-            testPa = pal.dpavVector(v3, v2)
-        self.assertEqual(context.exception.args[0],
-                         "In dpavVector, v1 must be a numpy array in which " \
-                         + "each row has 3 elements. " \
-                         + "Your rows have 6 elements.")
+        self.assertRaises(ValueError, pal.dpavVector, v3, v2)
 
-        with self.assertRaises(ValueError) as context:
-            testPa = pal.dpavVector(v1, v3)
-        self.assertEqual(context.exception.args[0],
-                         "In dpavVector, v2 must be a numpy array in which " \
-                         + "each row has 3 elements. " \
-                         + "Your rows have 6 elements.")
+        self.assertRaises(ValueError, pal.dpavVector, v1, v3)
 
-        with self.assertRaises(ValueError) as context:
-            testPa = pal.dpavVector(v1, np.random.random_sample(9))
-        self.assertEqual(context.exception.args[0],
-                         "The v2 you passed into dpavVector represents a single " \
-                         "point with 9 elements; it should have 3 elements")
+        self.assertRaises(ValueError, pal.dpavVector, v1, \
+                          np.random.random_sample(9))
 
     def test_caldj(self):
         djm = pal.caldj( 1999, 12, 31 )
@@ -587,18 +540,9 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raised when the input arrays are
         # of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.caldjVector(iy, im[:11], iday)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many months as " \
-                         + "years to caldjVector")
+        self.assertRaises(ValueError, pal.caldjVector, iy, im[:11], iday)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.caldjVector(iy, im, iday[:8])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many days as " \
-                         + "years to caldjVector")
-
+        self.assertRaises(ValueError, pal.caldjVector, iy, im, iday[:8])
 
     def test_daf2r(self):
         dr = pal.daf2r( 76, 54, 32.1 )
@@ -652,14 +596,7 @@ class TestPAL(unittest.TestCase) :
         # test that an exception is raised if you don't pass in
         # 3-D cartesian points
         dummyData = np.random.random_sample((20, 5))*10.0
-        with self.assertRaises(ValueError) as context:
-            aTest, bTest = pal.dcc2sVector(dummyData)
-        self.assertEqual(context.exception.args[0],
-                         "The input to dcc2sVector should be " \
-                         + "a 2-D numpy array in which each row " \
-                         + "is a point in 3-D Cartesian coordinates." \
-                         + " The rows of your input" \
-                         + " have 5 dimensions")
+        self.assertRaises(ValueError, pal.dcc2sVector, dummyData)
 
     def test_dcs2cVector(self):
         """
@@ -682,12 +619,7 @@ class TestPAL(unittest.TestCase) :
         np.testing.assert_array_almost_equal(np.sin(dec), np.sin(bTest), 12)
 
         # test that an exception is raised if you pass in arrays of different lengths
-        with self.assertRaises(ValueError) as context:
-            vTest = pal.dcs2cVector(ra, dec[:16])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many latitudes as longitudes " \
-                          + "into dcs2sVector")
-
+        self.assertRaises(ValueError, pal.dcs2cVector, ra, dec[:16])
 
     def test_cd2tf(self):
         ( sign, hours, minutes, seconds, fraction ) = pal.dd2tf( 4, -0.987654321 )
@@ -825,18 +757,9 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raised when you pass in
         # mis-matched input arrays
-        with self.assertRaises(ValueError) as context:
-            testDays = pal.dtf2dVector(iHour, iMin[:19], sec)
-        self.assertEqual(context.exception.args[0],
-                         "In dtf2dVector, imin does not have the " \
-                         + "same length as ihour")
+        self.assertRaises(ValueError, pal.dtf2dVector, iHour, iMin[:19], sec)
 
-        with self.assertRaises(ValueError) as context:
-            testDays = pal.dtf2dVector(iHour, iMin, sec[:19])
-        self.assertEqual(context.exception.args[0],
-                         "In dtf2dVector, sec does not have the " \
-                         + "same length as ihour")
-
+        self.assertRaises(ValueError, pal.dtf2dVector, iHour, iMin, sec[:19])
 
     def test_dtf2r(self):
         dr = pal.dtf2r( 23, 56, 59.1 )
@@ -877,19 +800,9 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raised when you pass in
         # mis-matched input arrays
-        with self.assertRaises(ValueError) as context:
-            testRad = pal.dtf2rVector(iHour, iMin[:19], sec)
-        self.assertEqual(context.exception.args[0],
-                         "In dtf2rVector, imin does not have the " \
-                         + "same length as ihour")
+        self.assertRaises(ValueError, pal.dtf2rVector, iHour, iMin[:19], sec)
 
-        with self.assertRaises(ValueError) as context:
-            testRad = pal.dtf2rVector(iHour, iMin, sec[:19])
-        self.assertEqual(context.exception.args[0],
-                         "In dtf2rVector, sec does not have the " \
-                         + "same length as ihour")
-
-
+        self.assertRaises(ValueError, pal.dtf2rVector, iHour, iMin, sec[:19])
 
     def test_dat(self):
         self.assertEqual( pal.dat( 43900 ), 18 )
@@ -1011,12 +924,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if inputs are not
         # of the same length
-        with self.assertRaises(ValueError) as context:
-            results = pal.de2hVector(haIn[:10], decIn, phi)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         + "Decs as Hour Angles to de2hVector")
-
+        self.assertRaises(ValueError, pal.de2hVector, haIn[:10], decIn, phi)
 
     def test_dh2eVector(self):
         """
@@ -1046,12 +954,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised when the input arrays
         # are of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.dh2eVector(az[:40], el, phi)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many elevations " \
-                         + "as azimuths to dh2eVector")
-
+        self.assertRaises(ValueError, pal.dh2eVector, az[:40], el, phi)
 
     def test_ecleq(self):
         (dr,dd) = pal.ecleq( 1.234, -0.123, 43210.0)
@@ -1086,12 +989,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays are
         # of different lenghts
-        with self.assertRaises(ValueError) as context:
-            results = pal.ecleqVector(dl[:4], db, mjd)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         + "longitudes as latitudes to ecleqVector")
-
+        self.assertRaises(ValueError, pal.ecleqVector, dl[:4], db, mjd)
 
     def test_ecmat(self):
         expected = np.array( [
@@ -1169,11 +1067,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if inpu arrays are of
         # different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.eqeclVector(ra, dec[:8], mjd)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of Decs " \
-                         + "as RAs to eqeclVector")
+        self.assertRaises(ValueError, pal.eqeclVector, ra, dec[:8], mjd)
 
     def test_eqeqx(self):
         self.assertAlmostEqual( pal.eqeqx( 53736 ), -0.8834195072043790156e-5, 15 )
@@ -1214,12 +1108,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised when the input
         # arrays are of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.eqgalVector(raIn[:2], decIn)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of RAs " \
-                         + "as Decs to eqgalVector")
-
+        self.assertRaises(ValueError, pal.eqgalVector, raIn[:2], decIn)
 
     def test_etrms(self):
         ev = pal.etrms( 1976.9 )
@@ -1416,32 +1305,20 @@ class TestPAL(unittest.TestCase) :
 
         # test that exceptions are raised when the input arrays are
         # of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk524Vector(ra5, dec5[:6], mura5, mudec5, px5, vr5)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many Decs as RAs into fk524Vector")
+        self.assertRaises(ValueError, pal.fk524Vector, ra5, dec5[:6], mura5, \
+                          mudec5, px5, vr5)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk524Vector(ra5, dec5, mura5[:8], mudec5, px5, vr5)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many RA proper motions as RAs into fk524Vector")
+        self.assertRaises(ValueError, pal.fk524Vector, ra5, dec5, mura5[:8], \
+                          mudec5, px5, vr5)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk524Vector(ra5, dec5, mura5, mudec5[:6], px5, vr5)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many Dec proper motions as RAs into fk524Vector")
+        self.assertRaises(ValueError, pal.fk524Vector, ra5, dec5, mura5, \
+                          mudec5[:6], px5, vr5)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5[:9], vr5)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many parallaxes as RAs into fk524Vector")
+        self.assertRaises(ValueError, pal.fk524Vector, ra5, dec5, mura5, \
+                          mudec5, px5[:9], vr5)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5, vr5[:9])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many radial velocities as RAs into fk524Vector")
-
-
+        self.assertRaises(ValueError, pal.fk524Vector, ra5, dec5, mura5, \
+                          mudec5, px5, vr5[:9])
 
     def test_fk45z(self):
         (r2000, d2000) = pal.fk45z( 1.2, -0.3, 1960 )
@@ -1476,11 +1353,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if the input arrays are of different
         # lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk45zVector(r1950, d1950[:8], epoch)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of Decs as RAs to " \
-                         + "fk45zVector")
+        self.assertRaises(ValueError, pal.fk45zVector, r1950, d1950[:8], epoch)
 
     def test_fk52h(self):
         inr5 = 1.234
@@ -1513,11 +1386,8 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if the input raList and decList
         # are of different sizes
-        with self.assertRaises(ValueError) as context:
-            testRa, testDec = pal.fk5hzVector(raList, decList[:24], 2000.0)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         "RAs as Decs to fk5hzVector")
+        self.assertRaises(ValueError, pal.fk5hzVector, raList, decList[:24], \
+                          2000.0)
 
     def test_hkf5zVector(self):
         """
@@ -1544,12 +1414,8 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if raList and decList are
         # of different lengths
-        with self.assertRaises(ValueError) as context:
-            ra, dec, dr, dd = pal.hfk5zVector(raList, decList[:77], 2000.0)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of RAs as " \
-                         + "Decs to hfk5zVector")
-
+        self.assertRaises(ValueError, pal.hfk5zVector,raList, decList[:77], \
+                          2000.0)
 
     def test_fk54z(self):
         (r1950, d1950, dr1950, dd1950) = pal.fk54z( 1.2, -0.3, 1960 )
@@ -1581,11 +1447,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays are of
         # different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.fk54zVector(r2000[:11], d2000, epoch)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of Decs as " \
-                         +"RAs to fk54zVector")
+        self.assertRaises(ValueError, pal.fk54zVector, r2000[:11], d2000, epoch)
 
     def test_flotin(self):
         pass
@@ -1612,12 +1474,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raise if input arrays
         # are of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.galeqVector(dlIn[:3], dbIn)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of longitudes " \
-                         + "as latitudes to galeqVector")
-
+        self.assertRaises(ValueError, pal.galeqVector, dlIn[:3], dbIn)
 
     def test_galsup(self):
         (dsl, dsb) = pal.galsup( 6.1, -1.4 )
@@ -1643,13 +1500,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if you pass in arrays with
         # different lengths
-        with self.assertRaises(ValueError) as context:
-            testSl, testSb = pal.galsupVector(llList[:55], bbList)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         + "Galactic longitudes as Galactic latitudes " \
-                         + "into galsupVector")
-
+        self.assertRaises(ValueError, pal.galsupVector, llList[:55], bbList)
 
     def test_geoc(self):
         lat = 19.822838905884 * pal.DD2R
@@ -1679,13 +1530,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised when you pass in different
         # numbers of longitudes as you do latitudes
-        with self.assertRaises(ValueError) as context:
-            testRa, testDec = pal.ge50Vector(llList, bbList[:45])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         + "Galactic longitudes as Galactic latitudes " \
-                         + "into ge50Vector")
-
+        self.assertRaises(ValueError, pal.ge50Vector, llList, bbList[:45])
 
     def test_gmst(self):
         self.assertAlmostEqual( pal.gmst( 53736 ), 1.754174971870091203, 12 )
@@ -1716,11 +1561,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays are
         # of different lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.gmstaVector(dateIn[:8], utIn)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into gmstaVector " \
-                         + "are of different lengths")
+        self.assertRaises(ValueError, pal.gmstaVector, dateIn[:8], utIn)
 
     def test_intin(self):
         s = "  -12345, , -0  2000  +     "
@@ -1814,11 +1655,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if the input arrays
         # are of inconsistent lengths
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkzVector(raIn[:4], decIn, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many RAs as Decs " \
-                         + "to mapqkzVector")
+        self.assertRaises(ValueError, pal.mapqkzVector, raIn[:4], decIn, amprms)
 
     def test_mapqkVector(self):
         amprms = pal.mappa(2010, 55927)
@@ -1848,35 +1685,20 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if the input arrays
         # are of inconsistent shapes
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkVector(raIn, decIn[:10], pmr, pmd, px, rv, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into mapqkVector are " \
-                         + "not of the same length")
+        self.assertRaises(ValueError, pal.mapqkVector, raIn, decIn[:10], pmr, \
+                          pmd, px, rv, amprms)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkVector(raIn, decIn, pmr[:10], pmd, px, rv, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into mapqkVector are " \
-                         + "not of the same length")
+        self.assertRaises(ValueError, pal.mapqkVector, raIn, decIn, pmr[:10], \
+                          pmd, px, rv, amprms)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkVector(raIn, decIn, pmr, pmd[:10], px, rv, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into mapqkVector are " \
-                         + "not of the same length")
+        self.assertRaises(ValueError, pal.mapqkVector, raIn, decIn, pmr, \
+                          pmd[:10], px, rv, amprms)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkVector(raIn, decIn, pmr, pmd, px[:10], rv, amprms)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into mapqkVector are " \
-                         + "not of the same length")
+        self.assertRaises(ValueError, pal.mapqkVector, raIn, decIn, pmr, \
+                          pmd, px[:10], rv, amprms)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.mapqkVector(raIn, decIn, pmr, pmd, px, rv[:10], amprms)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into mapqkVector are " \
-                         + "not of the same length")
+        self.assertRaises(ValueError, pal.mapqkVector, raIn, decIn, pmr, \
+                          pmd, px, rv[:10], amprms)
 
     def test_moon(self):
         expected = np.array( [
@@ -1955,11 +1777,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays
         # are of inconsistent length
-        with self.assertRaises(ValueError) as context:
-            results = pal.paVector(haIn[:4], decIn, phi)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many Decs as " \
-                         + "Hour Angles to paVector")
+        self.assertRaises(ValueError, pal.paVector, haIn[:4], decIn, phi)
 
     def test_pcd(self):
         disco = 178.585
@@ -2006,11 +1824,7 @@ class TestPAL(unittest.TestCase) :
 
         # make sure that an exceptoion is raised if you pass in
         # mismatched x and y vectors
-        with self.assertRaises(ValueError) as context:
-            xTestList, yTestLIst = pal.pcdVector(disco, x_in, y_in[:10])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of x as y " \
-                         + "coordinates to pcdVector")
+        self.assertRaises(ValueError, pal.pcdVector, disco, x_in, y_in[:10])
 
     def test_unpcdVector(self):
         """
@@ -2045,11 +1859,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if you pass in different numbers
         # of x and y coordinates
-        with self.assertRaises(ValueError) as context:
-            xTestList, yTestList = pal.unpcdVector(disco, x_in, y_in[:30])
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of x as y " \
-                         + "coordinates to unpcdVector")
+        self.assertRaises(ValueError, pal.unpcdVector, disco, x_in, y_in[:30])
 
     def test_planet(self):
         # palEl2ue
@@ -2268,35 +2078,20 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays are of
         # inconsistent length
-        with self.assertRaises(ValueError) as context:
-            results = pal.pmVector(raIn, decIn[:3], pmr, pmd, px, rv, ep0, ep1)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into pmVector are not all of " \
-                         + "the same length")
+        self.assertRaises(ValueError, pal.pmVector, raIn, decIn[:3], pmr, \
+                          pmd, px, rv, ep0, ep1)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.pmVector(raIn, decIn, pmr[:3], pmd, px, rv, ep0, ep1)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into pmVector are not all of " \
-                         + "the same length")
+        self.assertRaises(ValueError, pal.pmVector, raIn, decIn, pmr[:3], \
+                          pmd, px, rv, ep0, ep1)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.pmVector(raIn, decIn, pmr, pmd[:3], px, rv, ep0, ep1)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into pmVector are not all of " \
-                         + "the same length")
+        self.assertRaises(ValueError, pal.pmVector, raIn, decIn, pmr, \
+                          pmd[:3], px, rv, ep0, ep1)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.pmVector(raIn, decIn, pmr, pmd, px[:3], rv, ep0, ep1)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into pmVector are not all of " \
-                         + "the same length")
+        self.assertRaises(ValueError, pal.pmVector, raIn, decIn, pmr, \
+                          pmd, px[:3], rv, ep0, ep1)
 
-        with self.assertRaises(ValueError) as context:
-            results = pal.pmVector(raIn, decIn, pmr, pmd, px, rv[:3], ep0, ep1)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays you passed into pmVector are not all of " \
-                         + "the same length")
+        self.assertRaises(ValueError, pal.pmVector, raIn, decIn, pmr, \
+                          pmd, px, rv[:3], ep0, ep1)
 
     def test_polmo(self):
         (elong, phi, daz) = pal.polmo( 0.7, -0.5, 1.0e-6, -2.0e-6)
@@ -2543,23 +2338,11 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays
         # have different lengths
-        with self.assertRaises(ValueError) as context:
-            resutls = pal.dsepVector(ra1, dec1[:5], ra2, dec2)
-        self.assertEqual(context.exception.args[0],
-                        "The arrays you passed to dsepVector " \
-                         + "are not of the same length")
+        self.assertRaises(ValueError, pal.dsepVector, ra1, dec1[:5], ra2, dec2)
 
-        with self.assertRaises(ValueError) as context:
-            resutls = pal.dsepVector(ra1, dec1, ra2[:5], dec2)
-        self.assertEqual(context.exception.args[0],
-                        "The arrays you passed to dsepVector " \
-                         + "are not of the same length")
+        self.assertRaises(ValueError, pal.dsepVector, ra1, dec1, ra2[:5], dec2)
 
-        with self.assertRaises(ValueError) as context:
-            resutls = pal.dsepVector(ra1, dec1, ra2, dec2[:5])
-        self.assertEqual(context.exception.args[0],
-                        "The arrays you passed to dsepVector " \
-                         + "are not of the same length")
+        self.assertRaises(ValueError, pal.dsepVector, ra1, dec1, ra2, dec2[:5])
 
     def test_dsepvVector(self):
         """
@@ -2584,33 +2367,15 @@ class TestPAL(unittest.TestCase) :
             self.assertFalse(np.isnan(testSep[ii]))
 
         # test that exceptions are raised when they ought to be
-        with self.assertRaises(ValueError) as context:
-            testSep = pal.dsepvVector(v1, v2[0:19])
-        self.assertEqual(context.exception.args[0],
-                         "In dsepvVector v2 must either have one row or " \
-                         + "n rows, where n is the number of rows in v1")
+        self.assertRaises(ValueError, pal.dsepvVector, v1, v2[0:19])
 
         v3 = np.random.random_sample((nSamples,2))
-        with self.assertRaises(ValueError) as context:
-            testSep = pal.dsepvVector(v3, v2)
-        self.assertEqual(context.exception.args[0],
-                         "In dsepvVector v1 must be a numpy array " \
-                         + "in which each row corresponds to a direction " \
-                         + "in 3-D space.  Your v1 has 2 columns.")
+        self.assertRaises(ValueError, pal.dsepvVector, v3, v2)
 
-        with self.assertRaises(ValueError) as context:
-            testSep = pal.dsepvVector(v1, v3)
-        self.assertEqual(context.exception.args[0],
-                         "In dsepvVector v2 must be a numpy array " \
-                         + "in which each row corresponds to a direction " \
-                         + "in 3-D space.  Your v2 has 2 columns.")
+        self.assertRaises(ValueError, pal.dsepvVector, v1, v3)
 
-        with self.assertRaises(ValueError) as context:
-            testSep = pal.dsepvVector(v1, np.random.random_sample(4))
-        self.assertEqual(context.exception.args[0],
-                          "The v2 you passed to dsepvVector is a single point " \
-                          + "with 4 elements; it should have 3 elements")
-
+        self.assertRaises(ValueError, pal.dsepvVector, v1, \
+                          np.random.random_sample(4))
 
     def test_supgal(self):
         (dl, db) = pal.supgal( 6.1, -1.4 )
@@ -2641,11 +2406,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if the input arrays are of
         # different length
-        with self.assertRaises(ValueError) as context:
-            testDl, testDb = pal.supgalVector(dslList[:16], dsbList)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass the same number of " \
-                         + "longitudes as latitudes into supgalVector")
+        self.assertRaises(ValueError, pal.supgalVector, dslList[:16], dsbList)
 
     def test_tp(self):
         dr0 = 3.1
@@ -2704,12 +2465,8 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays
         # are not of the same shape
-        with self.assertRaises(ValueError) as context:
-            results = pal.ds2tpVector(raIn[:3], decIn, raz, decz)
-        self.assertEqual(context.exception.args[0],
-                         "You did not pass as many RAs as Decs " \
-                         + "to ds2tpVector")
-
+        self.assertRaises(ValueError, pal.ds2tpVector,raIn[:3], decIn, \
+                          raz, decz)
 
     def test_dtp2sVector(self):
         """
@@ -2740,12 +2497,7 @@ class TestPAL(unittest.TestCase) :
 
         # test that an exception is raised if input arrays are of
         # different sizes
-        with self.assertRaises(ValueError) as context:
-            results = pal.dtp2sVector(xi, eta[:20], raz, decz)
-        self.assertEqual(context.exception.args[0],
-                         "The arrays of tangent plane coordinates " \
-                         + "you passed to dtp2sVector are of " \
-                         + "different lengths")
+        self.assertRaises(ValueError, pal.dtp2sVector, xi, eta[:20], raz, decz)
 
     def test_vecmat(self):
         # Not everything is implemented here

--- a/test_pal.py
+++ b/test_pal.py
@@ -1109,6 +1109,66 @@ class TestPAL(unittest.TestCase) :
             self.assertTrue(dpx<0.001)
             self.assertTrue(dvr<0.01)
 
+    def test_Fk524Vectors(self):
+        """
+        Test that fk524Vector returns results consistent with
+        fk524
+        """
+        np.random.seed(135)
+        nSamples = 200
+        ra5 = np.random.random_sample(nSamples)*2.0*np.pi
+        dec5 = (np.random.random_sample(nSamples)-0.5)*np.pi
+        mura5 = 0.01*(np.random.random_sample(nSamples)-0.5)*200.0*np.radians(1.0/3600.0)
+        mudec5 = 0.01*(np.random.random_sample(nSamples)-0.5)*200.0*np.radians(1.0/3600.0)
+        px5 = np.random.random_sample(nSamples)
+        vr5 = (np.random.random_sample(nSamples)-0.5)*200.0
+
+        testRa, testDec, \
+        testMura, testMudec, \
+        testPx, testVr = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5, vr5)
+
+        for ii in range(nSamples):
+            controlRa, controlDec, \
+            controlMura, controlMudec, \
+            controlPx, controlVr = pal.fk524(ra5[ii], dec5[ii], mura5[ii], \
+                                             mudec5[ii], px5[ii], vr5[ii])
+
+            self.assertEqual(controlRa, testRa[ii])
+            self.assertEqual(controlDec, testDec[ii])
+            self.assertEqual(controlMura, testMura[ii])
+            self.assertEqual(controlMudec, testMudec[ii])
+            self.assertEqual(controlPx, testPx[ii])
+            self.assertEqual(controlVr, testVr[ii])
+
+        # test that exceptions are raised when the input arrays are
+        # of different lengths
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk524Vector(ra5, dec5[:6], mura5, mudec5, px5, vr5)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many Decs as RAs into fk524Vector")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk524Vector(ra5, dec5, mura5[:8], mudec5, px5, vr5)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many RA proper motions as RAs into fk524Vector")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk524Vector(ra5, dec5, mura5, mudec5[:6], px5, vr5)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many Dec proper motions as RAs into fk524Vector")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5[:9], vr5)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many parallaxes as RAs into fk524Vector")
+
+        with self.assertRaises(ValueError) as context:
+            results = pal.fk524Vector(ra5, dec5, mura5, mudec5, px5, vr5[:9])
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many radial velocities as RAs into fk524Vector")
+
+
+
     def test_fk45z(self):
         (r2000, d2000) = pal.fk45z( 1.2, -0.3, 1960 )
         self.assertAlmostEqual( r2000, 1.2097812228966762227, 11 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -68,6 +68,19 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( pal.airmas( 1.2354 ),
                                 3.015698990074724, 11 );
 
+    def test_airmassVector(self):
+        """
+        Test that airmassVector gives results consistent with airmass
+        """
+        np.random.seed(145)
+        nSamples = 1000
+        zd = np.random.random_sample(nSamples)*0.5*np.pi
+        testAm = pal.airmasVector(zd)
+        for ii in range(nSamples):
+            controlAm = pal.airmas(zd[ii])
+            self.assertEqual(controlAm, testAm[ii])
+            self.assertFalse(np.isnan(testAm[ii]))
+
     def test_altaz(self):
         (az, azd, azdd, el, eld, eldd, pa, pad, padd) = pal.altaz( 0.7, -0.7, -0.65 )
         self.assertAlmostEqual( az, 4.400560746660174, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -815,9 +815,21 @@ class TestPAL(unittest.TestCase) :
             self.assertEqual(controlEpj, testEpj[ii])
             self.assertFalse(np.isnan(testEpj[ii]))
 
-
     def test_epj2d(self):
         self.assertAlmostEqual( pal.epj2d(2010.077), 55225.124250, 6 )
+
+    def test_epj2dVector(self):
+        """
+        Test that epj2dVector returns results consistent with epj
+        """
+        np.random.seed(45367)
+        nSamples = 300
+        epj = 2000.0 + np.random.random_sample(nSamples)*50.0
+        testMjd = pal.epj2dVector(epj)
+        for ii in range(nSamples):
+            controlMjd = pal.epj2d(epj[ii])
+            self.assertEqual(controlMjd, testMjd[ii])
+            self.assertFalse(np.isnan(testMjd[ii]))
 
     def test_eqecl(self):
         (dl, db) = pal.eqecl( 0.789, -0.123, 46555 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -936,6 +936,31 @@ class TestPAL(unittest.TestCase) :
         self.assertAlmostEqual( dr5, 0.000000006822074, 13 )
         self.assertAlmostEqual( dd5, -0.000000002334012, 13 )
 
+    def test_fk5hzVector(self):
+        """
+        Test that fk5hzVector returns results consistent with
+        fk5hz
+        """
+        np.random.seed(132)
+        nSamples = 200
+        raList = np.random.random_sample(nSamples)*2.0*np.pi
+        decList = (np.random.random_sample(nSamples)-0.5)*np.pi
+        testRa, testDec = pal.fk5hzVector(raList, decList, 2000.0)
+
+        for ii in range(nSamples):
+            controlRa, controlDec = pal.fk5hz(raList[ii], decList[ii], 2000.0)
+            self.assertEqual(controlRa, testRa[ii])
+            self.assertEqual(controlDec, testDec[ii])
+
+        # test that an exception is raised if the input raList and decList
+        # are of different sizes
+        with self.assertRaises(ValueError) as context:
+            testRa, testDec = pal.fk5hzVector(raList, decList[:24], 2000.0)
+        self.assertEqual(context.exception.message,
+                         "You did not pass the same number of " \
+                         "RAs as Decs to fk5hzVector")
+
+
     def test_fk54z(self):
         (r1950, d1950, dr1950, dd1950) = pal.fk54z( 1.2, -0.3, 1960 )
         self.assertAlmostEqual( r1950, 1.1902221805755279771, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -1953,6 +1953,14 @@ class TestPAL(unittest.TestCase) :
         for pt, pc in zip(paTest, paControl):
             self.assertAlmostEqual(pt, pc, 12)
 
+        # test that an exception is raised if input arrays
+        # are of inconsistent length
+        with self.assertRaises(ValueError) as context:
+            results = pal.paVector(haIn[:4], decIn, phi)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many Decs as " \
+                         + "Hour Angles to paVector")
+
     def test_pcd(self):
         disco = 178.585
         REFX = 0.0123

--- a/test_pal.py
+++ b/test_pal.py
@@ -569,6 +569,28 @@ class TestPAL(unittest.TestCase) :
         self.assertEqual( sec, 22 )
         self.assertEqual( f, 6484 )
 
+    def test_dr2tfVector(self):
+        """
+        Test that dr2tfVector produces the same results as
+        dr2tf
+        """
+        np.random.seed(128)
+        nSamples = 200
+        angleList = (np.random.random_sample(nSamples)-0.5)*4.0*np.pi
+        for npd in [2, 3, 4, 5]:
+            testSign, testHr, \
+            testMin, testSec, testFrac = pal.dr2tfVector(npd, angleList)
+
+            for ii in range(nSamples):
+                controlSign, controlHr, \
+                controlMin, controlSec, controlFrac = pal.dr2tf(npd, angleList[ii])
+
+                self.assertEqual(controlSign, testSign[ii])
+                self.assertEqual(controlHr, testHr[ii])
+                self.assertEqual(controlMin, testMin[ii])
+                self.assertEqual(controlSec, testSec[ii])
+                self.assertEqual(controlFrac, testFrac[ii])
+
     def test_dtf2d(self):
         dd = pal.dtf2d( 23, 56, 59.1 )
         self.assertAlmostEqual( dd, 0.99790625, 12 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -131,6 +131,13 @@ class TestPAL(unittest.TestCase) :
             self.assertAlmostEqual(padC[i], padT[i], 12)
             self.assertAlmostEqual(paddC[i], paddT[i], 12)
 
+        with self.assertRaises(ValueError) as context:
+            results = pal.altazVector(haIn[:10], decIn, phi)
+        self.assertEqual(context.exception.message,
+                         "You did not pass as many Decs as Hour Angles " \
+                         + "to altazVector")
+
+
     def test_amp(self):
         (rm, dm) = pal.amp( 2.345, -1.234, 50100., 1990. )
         self.assertAlmostEqual( rm, 2.344472180027961, 6 )

--- a/test_pal.py
+++ b/test_pal.py
@@ -978,6 +978,11 @@ class TestPAL(unittest.TestCase) :
             self.assertEqual(testDr[ii], controlDr)
             self.assertEqual(testDd[ii], controlDd)
 
+        # test hfk5zVector anf fk5hzVector invert each other
+        ra5, dec5 = pal.fk5hzVector(testRa, testDec, 2000.0)
+        np.testing.assert_array_almost_equal(ra5, raList, 11)
+        np.testing.assert_array_almost_equal(dec5, decList, 11)
+
         # test that an exception is raised if raList and decList are
         # of different lengths
         with self.assertRaises(ValueError) as context:


### PR DESCRIPTION
This pull request adds "vectorized" versions of the following methods (i.e. methods that can input and output numpy arrays)

palRefv -- adjust a cartesian vector for refraction
palRefro -- refraction for optical bands as a function of zenith distance
palPcd -- calculate a pincushion/barrel distortion
palUnpcd -- remove a pincushion/barrel distortion
palDbear -- find the angle between points on a sphere
palDaf2r -- convert degrees, min, sec to radians
palDav2m -- convert cartesian to spherical coordinates
palDcc2s -- convert spherical coordinates to direction cosines
palDd2tf -- convert days to hours, minutes, seconds
palDpav -- the bearing of one celestial object with respect to another
palDr2af -- convert radians to degrees, minutes, seconds
palDr2tf -- convert radians to hours, minutes, seconds
palDranrm -- normalize an angle to the range 0 to 2pi
palDsepv -- angle between two vectors
palDtf2d -- convert hours, minutes, seconds to days
palDtf2r -- convert hours, minutes, seconds to radians
palEpj -- convert MJD to Julian Epoch
palEpj2D -- convert Julian Epoch to MJD
palFk5hz -- convert FK5 position to Hipparcos position
palHfk5hz -- convert Hipparcos position to FK5 position
palOapqk -- observed place to apparent place (quick)
palMap -- mean position to geocentric apparent position
palGe50 -- Galactic coordinates to B1950 Fk4 coordinates
palGalsup -- galactic coordinates to supergalactic coordinates
palSupgal -- supergalactic coordinates to galactic coordinates
palFk524 -- FK5 position to FK4 position
palFK54z -- ditto, assuming no parallax or proper motion
palFK45z -- FK4 to FK5 without parallax or proper motion
palEqecl -- equatorial to ecliptic coordinates
palEcleq -- ecliptic to equatorial
palDtps2c -- RA, Dec from tangent plane
palDtp2s -- tangent plane to spherical coordinates
palDrange -- normalize an angle to the range -pi to pi
palDmoon -- geocentric position and velocity of the moon
palDjcal -- convert MJD to Gregorian calendar
palDh2e -- horizon to equatorial coordinates
palCaldj -- Gregorian calendar to MJD
palAmpqk -- quick geocentric apparent to mean place
palAirmas -- calculate airmass from zenith distance

It also adds a unit test for Fk524 based on data from the Explanatory Supplement to the Astronomical Almanac

It also updates all of the previously vectorized methods so that their docstrings are more explanatory and so that they raise exceptions when they are given nonsense inputs (i.e. numpy arrays of mismatched sizes).

If this gets merged, could you please tag a new version so that I can incorporate these vectorized methods into the LSST Sims stack?  Thank you.